### PR TITLE
⚡ Bolt: Cache NREL API request to prevent duplicate data download

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-05-23 - Avoid premature optimization
+**Learning:** Avoid premature optimization of cold paths and optimizations that make code unreadable.
+**Action:** Measure first, optimize second. Keep code readable.
+
+## 2026-03-06 - Double HTTP Requests Anti-Pattern
+**Learning:** Found an anti-pattern where an HTTP request is made using `requests.get` to validate parameters and then `pandas.read_csv(r.url)` is called with the resulting URL. This causes pandas to silently make a second full HTTP request to download the exact same data, wasting bandwidth, latency, and API limits.
+**Action:** When a library like pandas accepts a URL or a file-like object, pass `io.BytesIO(response.content)` from the validated `requests.Response` object instead of the URL string to prevent redundant network calls.

--- a/nrel_psm3_2_epw/assets.py
+++ b/nrel_psm3_2_epw/assets.py
@@ -1,3 +1,4 @@
+import io
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from datetime import datetime
 import re
@@ -94,8 +95,9 @@ def download_epw(
                 error_payload = {"message": r.text.strip()}
             raise RuntimeError(f"NREL request failed ({r.status_code}) for {safe_url}: {error_payload}")
 
-        # Return just the first 2 lines to get metadata:
-        all_data = pd.read_csv(r.url)
+        # Parse the downloaded content instead of requesting the URL again
+        # This prevents pandas from making a second HTTP request for the same data
+        all_data = pd.read_csv(io.BytesIO(r.content))
 
         if all_data is None:
             raise RuntimeError("Could not retrieve any data")

--- a/tests/test_assets_unit.py
+++ b/tests/test_assets_unit.py
@@ -6,13 +6,14 @@ from nrel_psm3_2_epw import assets
 
 
 class DummyResponse:
-    def __init__(self, ok, url, status_code=200, json_data=None, json_error=None, text=""):
+    def __init__(self, ok, url, status_code=200, json_data=None, json_error=None, text="", content=b""):
         self.ok = ok
         self.url = url
         self.status_code = status_code
         self._json_data = json_data
         self._json_error = json_error
         self.text = text
+        self.content = content
 
     def json(self):
         if self._json_error:


### PR DESCRIPTION
💡 What: The optimization replaces `pd.read_csv(r.url)` with `pd.read_csv(io.BytesIO(r.content))` when parsing the CSV returned from NREL API.
🎯 Why: The previous code made an initial request to NREL via `requests.get()` to validate the parameters, but then passed `r.url` to `pandas.read_csv()`, causing pandas to silently make a second full HTTP request to download the exact same data.
📊 Impact: Expected to cut network latency and bandwidth in half for the data download step by entirely removing the redundant HTTP request. Rate limit usage will also be halved.
🔬 Measurement: Verified using an HTTP mocking server that only one request is made instead of two. Also updated the test mock `DummyResponse` to have `content` attribute to pass existing unit tests. Code is cleaner and faster. I also added a journal entry in `.jules/bolt.md` documenting this double-request anti-pattern learning.

---
*PR created automatically by Jules for task [10622319839844184435](https://jules.google.com/task/10622319839844184435) started by @kastnerp*