### PR TITLE
Remove uv dependency from release workflow and build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
       - name: Python Semantic Release
         uses: python-semantic-release/python-semantic-release@v9.21.0
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
 version_toml = [
     "pyproject.toml:project.version",
 ]
-build_command = "uv build"
+build_command = "pip install build && python -m build"
 
 [tool.semantic_release.branches.main]
 match = "(main|master)"


### PR DESCRIPTION
## Summary
This PR removes the dependency on `uv` from the release workflow and build configuration, replacing it with the standard `pip` and `build` tools.

## Key Changes
- Removed the `setup-uv` action step from the GitHub Actions release workflow
- Updated the semantic release build command from `uv build` to `pip install build && python -m build`

## Details
The changes simplify the release pipeline by eliminating the need for the `uv` package manager. The build process now uses the standard Python packaging tools (`build` package) instead, which are more widely supported and don't require an additional setup step in the CI/CD workflow.

https://claude.ai/code/session_01SqjYWGRjhsP5CdjNCVyqRQ