### PR TITLE
🎨 Palette: Improve form validation UX with dynamic disabled states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,7 @@
 ## 2024-05-20 - Suppressing Streamlit's Missing Secrets Warning
 **Learning:** Accessing `st.secrets` directly when a `.streamlit/secrets.toml` file does not exist triggers an ugly, unavoidable pink error trace in the Streamlit UI, creating a jarring first impression for new users setting up the project locally.
 **Action:** When retrieving optional API keys or configurations from Streamlit's secrets manager, proactively check for the existence of `secrets.toml` files (e.g., using `os.path.isfile()` for `./.streamlit/secrets.toml` and `~/.streamlit/secrets.toml`) before accessing `st.secrets` to gracefully handle unconfigured environments and maintain a clean user interface.
+
+## 2026-03-12 - Using Dynamic Disabled States for Form Validation
+**Learning:** In Streamlit applications, using `st.stop()` inside button click handlers for form validation provides a poor user experience. The button remains clickable even with invalid inputs, making the UI feel unresponsive when clicked, and the error is only shown after an action is attempted.
+**Action:** Implement real-time inline validation by evaluating input states *before* the submit button is rendered. Use this evaluation state to dynamically set the button's `disabled` parameter and provide contextual validation feedback via the `help` parameter, ensuring a responsive and intuitive UI.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -214,41 +214,45 @@ def main():
             help="A specific year (>=1998) or a TMY identifier like 'tmy' or 'tmy-2024'",
         )
 
-    button_help = (
-        "Initiates request to NREL API to download EPW file"
-        if api_key
-        else "Please provide an API key above to enable this button"
-    )
+    current_year = datetime.now().year
+    year_str = str(year).strip()
+    year_is_valid = True
+    year_warning = ""
+
+    # Basic Year Validation
+    if year_str.isdigit():
+        year_int = int(year_str)
+        if year_int in (current_year, current_year - 1):
+            year_is_valid = False
+            year_warning = (
+                f"NREL does not provide data for the current year {year}. "
+                f"It is also unlikely that there is data availability for {year_int - 1}."
+            )
+        elif year_int < MIN_YEAR:
+            year_is_valid = False
+            year_warning = (
+                f"NREL does not provide data for the year {year}. "
+                f"The earliest year data is available for is {MIN_YEAR}."
+            )
+    else:
+        if not year_str.lower().startswith(("tmy", "tgy", "tdy")):
+            year_is_valid = False
+            year_warning = "Year must be a numeric year (>=1998) or a TMY name like tmy or tmy-2024."
+
+    if not api_key:
+        button_help = "Please provide an API key above to enable this button"
+    elif not year_is_valid:
+        button_help = year_warning
+    else:
+        button_help = "Initiates request to NREL API to download EPW file"
+
     if st.button(
         "Request from NREL",
         type="primary",
         help=button_help,
-        disabled=not bool(api_key),
+        disabled=not bool(api_key) or not year_is_valid,
         icon=":material/cloud_download:",
     ):
-        current_year = datetime.now().year
-        year_str = str(year).strip()
-
-        # Basic Year Validation
-        if year_str.isdigit():
-            year_int = int(year_str)
-            if year_int in (current_year, current_year - 1):
-                st.warning(
-                    f"NREL does not provide data for the current year {year}. "
-                    f"It is also unlikely that there is data availability for {year_int - 1}."
-                )
-                st.stop()
-            elif year_int < MIN_YEAR:
-                st.warning(
-                    f"NREL does not provide data for the year {year}. "
-                    f"The earliest year data is available for is {MIN_YEAR}."
-                )
-                st.stop()
-        else:
-            if not year_str.lower().startswith(("tmy", "tgy", "tdy")):
-                st.warning("Year must be a numeric year (>=1998) or a TMY name like tmy or tmy-2024.")
-                st.stop()
-
         with st.spinner("Requesting data from NREL..."):
             try:
                 file_name = download_epw(

--- a/test_frontend.py
+++ b/test_frontend.py
@@ -1,13 +1,44 @@
+import os
 from playwright.sync_api import sync_playwright
 
-def verify_frontend():
+def test_validation_ux():
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
         page = browser.new_page()
-        page.goto("http://localhost:8501")
-        page.wait_for_timeout(5000)
-        page.screenshot(path="verification.png")
-        browser.close()
+
+        try:
+            # Navigate to the Streamlit app
+            page.goto("http://localhost:8501")
+
+            # Wait for the app to load
+            page.wait_for_selector("text=NREL-PSM3-2-EPW")
+
+            # Find the Year input field and fill it with an invalid year
+            year_input = page.locator('input[aria-label="Year"]')
+            year_input.fill("1990")
+            year_input.press("Enter")
+
+            # Wait a moment for Streamlit to rerun
+            page.wait_for_timeout(2000)
+
+            # Check if the "Request from NREL" button is disabled
+            button = page.locator('button', has_text="Request from NREL").first
+
+            # Take a screenshot showing the button state
+            # Hover over the button to show the tooltip if possible
+            button.hover(force=True)
+            page.wait_for_timeout(1000)
+
+            # Make sure we have a directory for verification
+            os.makedirs("/home/jules/verification", exist_ok=True)
+
+            page.screenshot(path="/home/jules/verification/validation_ux3.png")
+            print("Screenshot taken at /home/jules/verification/validation_ux3.png")
+
+        except Exception as e:
+            print(f"Error during verification: {e}")
+        finally:
+            browser.close()
 
 if __name__ == "__main__":
-    verify_frontend()
+    test_validation_ux()

--- a/test_frontend.py
+++ b/test_frontend.py
@@ -1,44 +1,13 @@
-import os
 from playwright.sync_api import sync_playwright
 
-def test_validation_ux():
+def verify_frontend():
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
         page = browser.new_page()
-
-        try:
-            # Navigate to the Streamlit app
-            page.goto("http://localhost:8501")
-
-            # Wait for the app to load
-            page.wait_for_selector("text=NREL-PSM3-2-EPW")
-
-            # Find the Year input field and fill it with an invalid year
-            year_input = page.locator('input[aria-label="Year"]')
-            year_input.fill("1990")
-            year_input.press("Enter")
-
-            # Wait a moment for Streamlit to rerun
-            page.wait_for_timeout(2000)
-
-            # Check if the "Request from NREL" button is disabled
-            button = page.locator('button', has_text="Request from NREL").first
-
-            # Take a screenshot showing the button state
-            # Hover over the button to show the tooltip if possible
-            button.hover(force=True)
-            page.wait_for_timeout(1000)
-
-            # Make sure we have a directory for verification
-            os.makedirs("/home/jules/verification", exist_ok=True)
-
-            page.screenshot(path="/home/jules/verification/validation_ux3.png")
-            print("Screenshot taken at /home/jules/verification/validation_ux3.png")
-
-        except Exception as e:
-            print(f"Error during verification: {e}")
-        finally:
-            browser.close()
+        page.goto("http://localhost:8501")
+        page.wait_for_timeout(5000)
+        page.screenshot(path="verification.png")
+        browser.close()
 
 if __name__ == "__main__":
-    test_validation_ux()
+    verify_frontend()

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ wheels = [
 
 [[package]]
 name = "nrel-psm3-2-epw"
-version = "4.0.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
**💡 What:** Moved form validation logic out of the `st.button` click handler and evaluated the input state dynamically to disable the "Request from NREL" button when invalid inputs (e.g., incorrect year) are provided. A contextual validation warning is now shown in the button's tooltip (`help`) when disabled.

**🎯 Why:** In Streamlit applications, using `st.stop()` inside button click handlers for form validation provides a poor user experience. The button remains clickable even with invalid inputs, making the UI feel unresponsive, and the error is only shown after an action is attempted. This improves the real-time feedback.

**📸 Before/After:** See the verification screenshots `validation_ux3.png`.

**♿ Accessibility:** Enhances UX by proactively preventing invalid submissions and using the button's native `help` (tooltip) attribute for accessibility-friendly feedback, instead of generic `st.warning` boxes that only appear post-click.

Updated `.Jules/palette.md` with the newly learned UX pattern.

---
*PR created automatically by Jules for task [3864661238726438314](https://jules.google.com/task/3864661238726438314) started by @kastnerp*