### PR TITLE
🎨 Palette: Improve disabled state context and button affordance

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2024-06-18 - Inline Error Messages for Better Form Validation Feedback
 **Learning:** In Streamlit applications, relying solely on tooltips over disabled buttons to communicate form validation errors hides crucial context from the user until they attempt to interact with the disabled element.
 **Action:** Implement real-time inline validation feedback by evaluating input states *before* the submit button is rendered and displaying explicit error or warning messages directly adjacent to the relevant input fields using `st.error` or `st.warning`.
+
+## 2026-03-15 - Dynamic Disabled States Need Explicit Inline Feedback
+**Learning:** In Streamlit apps, relying solely on a button's `help` tooltip to explain *why* it is disabled (e.g., missing API key) is completely inaccessible to touch device users (mobile/tablet) and often missed by keyboard-only users.
+**Action:** When a primary action button is disabled due to missing prerequisites, always provide an explicit, visible inline message (e.g., `st.warning` or `st.error`) near the button or the missing input field to ensure all users immediately understand the required action.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -258,6 +258,7 @@ def main():
 
     if not api_key:
         button_help = "Please provide an API key above to enable this button"
+        st.warning("Please provide an API key in the 'API Key Configuration' section above to request data.", icon="🔑")
     elif not year_is_valid:
         button_help = year_warning
     else:
@@ -298,7 +299,14 @@ def main():
             with open(file_name, "rb") as f:
                 s = f.read()
                 st.success("Data successfully processed! Click below to download.")
-                st.download_button(label="Download EPW", data=s, file_name=file_name, mime="text/plain", type="primary")
+                st.download_button(
+                    label="Download EPW",
+                    data=s,
+                    file_name=file_name,
+                    mime="text/plain",
+                    type="primary",
+                    icon=":material/download:",
+                )
 
             st.markdown("---")
             st.markdown("### Visualize your EPW file")


### PR DESCRIPTION
💡 What: Added an explicit inline `st.warning` message above the "Request from NREL" button when the API key is missing. Additionally, added a download icon to the EPW download button.
🎯 Why: Relying solely on the `help` tooltip over a disabled button hides the reason the action is disabled from touch device (mobile/tablet) users, making the app feel unresponsive or broken. Adding an explicit warning ensures all users immediately understand they need to configure an API key. Adding an icon to the download button improves its visual affordance.
📸 Before/After: See screenshot for the new inline warning.
♿ Accessibility: Significant improvement for mobile users and keyboard navigators who often miss tooltips on disabled elements.

---
*PR created automatically by Jules for task [16497181011513664301](https://jules.google.com/task/16497181011513664301) started by @kastnerp*