### PR TITLE
🎨 Palette: Make interactive map responsive across all device sizes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,7 @@
 ## 2026-03-15 - Dynamic Disabled States Need Explicit Inline Feedback
 **Learning:** In Streamlit apps, relying solely on a button's `help` tooltip to explain *why* it is disabled (e.g., missing API key) is completely inaccessible to touch device users (mobile/tablet) and often missed by keyboard-only users.
 **Action:** When a primary action button is disabled due to missing prerequisites, always provide an explicit, visible inline message (e.g., `st.warning` or `st.error`) near the button or the missing input field to ensure all users immediately understand the required action.
+
+## 2026-03-20 - Responsive Sizing for Interactive Map Components
+**Learning:** Hardcoding a fixed pixel width (e.g., `width=700`) for large interactive UI components like maps (e.g., `streamlit-folium`) causes significant usability issues on smaller screens (mobile/tablet) by introducing forced horizontal scrolling and breaking responsive layouts. Conversely, it wastes available screen real estate on larger desktop monitors.
+**Action:** When integrating large interactive components in Streamlit apps, explicitly opt-in to fluid, responsive sizing by using `use_container_width=True` instead of specifying static pixel dimensions. This ensures the component gracefully adapts to all device sizes, significantly improving mobile accessibility and desktop presentation.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -161,7 +161,7 @@ def main():
     st.write("Click on the map to select a location:")
     m = folium.Map(location=[33.770, -84.3824], zoom_start=4)
     m.add_child(folium.LatLngPopup())
-    map_data = st_folium(m, height=400, width=700)
+    map_data = st_folium(m, height=400, use_container_width=True)
 
     # Initialize lat/lon with defaults
     default_lat = 33.770


### PR DESCRIPTION
### 💡 What
Updated the `st_folium` interactive map component to use a responsive container width (`use_container_width=True`) instead of a hardcoded width of 700 pixels. Also updated `.Jules/palette.md` to record learnings on responsive map sizing.

### 🎯 Why
A hardcoded width of 700 pixels causes poor user experience on mobile devices and tablets by forcing horizontal scrolling, while under-utilizing available screen real estate on larger desktop monitors. This change ensures the map adapts fluidly to whatever screen or container it is viewed in.

### 📸 Before/After
*   **Before:** Map has fixed 700px width, causing scrolling on small screens.
*   **After:** Map gracefully expands or shrinks to fit the container width.

### ♿ Accessibility
This fundamentally improves accessibility for mobile and tablet users who would previously struggle to pan the map without triggering browser-level horizontal scrolling. It adheres to responsive design principles.

---
*PR created automatically by Jules for task [8633784821668243150](https://jules.google.com/task/8633784821668243150) started by @kastnerp*