### PR TITLE
🎨 Palette: Add inline validation for Location Name

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -30,3 +30,7 @@
 ## 2026-03-20 - Responsive Sizing for Interactive Map Components
 **Learning:** Hardcoding a fixed pixel width (e.g., `width=700`) for large interactive UI components like maps (e.g., `streamlit-folium`) causes significant usability issues on smaller screens (mobile/tablet) by introducing forced horizontal scrolling and breaking responsive layouts. Conversely, it wastes available screen real estate on larger desktop monitors.
 **Action:** When integrating large interactive components in Streamlit apps, explicitly opt-in to fluid, responsive sizing by using `use_container_width=True` instead of specifying static pixel dimensions. This ensures the component gracefully adapts to all device sizes, significantly improving mobile accessibility and desktop presentation.
+
+## 2024-05-18 - Inline Validation for Forms
+**Learning:** Depending entirely on button disabled states or tooltip hints for form validation can leave users confused when fields are cleared, especially since tooltips are inaccessible on mobile devices.
+**Action:** Always provide explicit, inline feedback right next to the corresponding input fields using tools like `st.error` before disabling form submission buttons.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -219,6 +219,9 @@ def main():
             placeholder="e.g., Atlanta",
             help="A descriptive name for the location, used to generate the output filename",
         )
+        location_is_valid = bool(str(location).strip())
+        if not location_is_valid:
+            st.error("Please provide a location name.", icon="⚠️")
     with col4:
         year = st.text_input(
             "Year",
@@ -261,6 +264,8 @@ def main():
         st.warning("Please provide an API key in the 'API Key Configuration' section above to request data.", icon="🔑")
     elif not year_is_valid:
         button_help = year_warning
+    elif not location_is_valid:
+        button_help = "Please provide a valid location name."
     else:
         button_help = "Initiates request to NREL API to download EPW file"
 
@@ -268,7 +273,7 @@ def main():
         "Request from NREL",
         type="primary",
         help=button_help,
-        disabled=not bool(api_key) or not year_is_valid,
+        disabled=not bool(api_key) or not year_is_valid or not location_is_valid,
         icon=":material/cloud_download:",
     ):
         with st.spinner("Requesting data from NREL..."):


### PR DESCRIPTION
💡 **What**: Added real-time inline validation to the "Location Name" field. When the field is empty, it displays an explicit error message, disables the primary "Request from NREL" submit button, and updates the button's tooltip.

🎯 **Why**: Previously, clearing the location field could lead to awkwardly formatted output filenames or unhandled backend errors, and users might not understand why the submit button was suddenly disabled. Relying solely on tooltips over disabled buttons is bad UX because they are inaccessible on mobile devices.

📸 **Before/After**: 
Before: No explicit indication if the location was cleared.
After: Explicit red `st.error` box appears directly below the empty field, preventing form submission.

♿ **Accessibility**: Provides immediate visual feedback (the inline error) and ensures all users (including mobile and screen-reader users) understand why the form cannot be submitted, rather than hiding the reason inside a mouse-only tooltip.

---
*PR created automatically by Jules for task [13552340081463032302](https://jules.google.com/task/13552340081463032302) started by @kastnerp*