### PR TITLE
🎨 Palette: Proactive inline validation for API keys

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -34,3 +34,7 @@
 ## 2024-05-18 - Inline Validation for Forms
 **Learning:** Depending entirely on button disabled states or tooltip hints for form validation can leave users confused when fields are cleared, especially since tooltips are inaccessible on mobile devices.
 **Action:** Always provide explicit, inline feedback right next to the corresponding input fields using tools like `st.error` before disabling form submission buttons.
+
+## 2026-03-22 - Proactive Inline Validation for External Tokens
+**Learning:** In Streamlit apps that connect to external APIs, only verifying inputs on submission (or worse, letting the backend handle invalid inputs and fail) leads to unnecessary network requests, delayed failure messages, and user frustration.
+**Action:** When capturing well-structured credentials (like API keys) or strictly formatted strings, always implement proactive, inline validation based on expected attributes (e.g., string length or regex) *before* submission, providing immediate visual feedback right next to the relevant input field.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -154,7 +154,10 @@ def main():
         if api_key_override:
             api_key = api_key_override
             api_key_source = "user"
-            st.success("User API key loaded.")
+            if len(api_key.strip()) != 40:
+                st.warning("User API key loaded, but it is not 40 characters long. NREL keys are typically exactly 40 characters.", icon="⚠️")
+            else:
+                st.success("User API key loaded.", icon="✅")
         elif default_api_key:
             api_key = default_api_key
             api_key_source = "default"
@@ -162,11 +165,11 @@ def main():
             # Verify Hash
             key_hash = hashlib.sha256(api_key.strip().encode()).hexdigest()
             if key_hash == VALID_API_KEY_HASH:
-                st.success("Default API key loaded (Verified).")
+                st.success("Default API key loaded (Verified).", icon="✅")
             else:
-                st.warning("Default API key loaded (Unverified).")
+                st.warning("Default API key loaded (Unverified).", icon="⚠️")
         else:
-            st.error("No API key loaded. Please provide one above.")
+            st.error("No API key loaded. Please provide one above.", icon="🛑")
 
     st.markdown("### Location & Time Details")
 


### PR DESCRIPTION
💡 What: Added proactive inline length validation for user-provided API keys.
🎯 Why: NREL API keys are exactly 40 characters. Previously, users typing 39 characters would only find out their key was invalid by clicking submit and waiting for a network error. Now they receive immediate visual feedback via `st.warning`.
📸 Before/After: Visual warning dynamically replaces the `st.success` message when length is not 40. Added `✅`/`⚠️`/`🛑` icons to all API key loading notifications for better scanning.
♿ Accessibility: Improved form validation feedback. Users now get proactive textual context near the relevant input field before attempting a primary action.

---
*PR created automatically by Jules for task [15526395113371478280](https://jules.google.com/task/15526395113371478280) started by @kastnerp*