### PR TITLE
🎨 Palette: Add max_chars constraint to API key input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -38,3 +38,7 @@
 ## 2026-03-22 - Proactive Inline Validation for External Tokens
 **Learning:** In Streamlit apps that connect to external APIs, only verifying inputs on submission (or worse, letting the backend handle invalid inputs and fail) leads to unnecessary network requests, delayed failure messages, and user frustration.
 **Action:** When capturing well-structured credentials (like API keys) or strictly formatted strings, always implement proactive, inline validation based on expected attributes (e.g., string length or regex) *before* submission, providing immediate visual feedback right next to the relevant input field.
+
+## 2024-05-22 - Visual Constraint Cues via Native Input Attributes
+**Learning:** In Streamlit applications, requiring specific lengths for inputs like API keys without providing explicit UI constraints causes user frustration when copying/pasting malformed strings, relying on form validation that only triggers later.
+**Action:** Always provide immediate visual constraints for required lengths. Utilizing `max_chars` on Streamlit `st.text_input` components implicitly restricts invalid inputs, and provides a clear character counter (e.g. `0/40`), acting as proactive inline validation without extra code.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -149,6 +149,7 @@ def main():
             value="",
             type="password",
             help="Overrides the default API key if provided.",
+            max_chars=40,
         )
 
         if api_key_override:

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ wheels = [
 
 [[package]]
 name = "nrel-psm3-2-epw"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
💡 **What:** Added `max_chars=40` parameter to the NREL API key text input.
🎯 **Why:** The NREL API key is exactly 40 characters long. Previously, users could paste strings with trailing spaces or mistakenly long strings, and validation would only catch it upon submission. This change adds proactive, inline validation via a visual character counter, implicitly guiding the user without requiring extra custom code.
📸 **Before/After:** The API key input now displays a `0/40` character counter inside the input field when focused or when text is entered.
♿ **Accessibility:** This implicit constraint prevents invalid input earlier in the process, making the form more user-friendly and reducing submission errors.

---
*PR created automatically by Jules for task [992721552596924747](https://jules.google.com/task/992721552596924747) started by @kastnerp*