### PR TITLE
🎨 Palette: Add async feedback for map geocoding and input constraints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,3 +42,7 @@
 ## 2024-05-22 - Visual Constraint Cues via Native Input Attributes
 **Learning:** In Streamlit applications, requiring specific lengths for inputs like API keys without providing explicit UI constraints causes user frustration when copying/pasting malformed strings, relying on form validation that only triggers later.
 **Action:** Always provide immediate visual constraints for required lengths. Utilizing `max_chars` on Streamlit `st.text_input` components implicitly restricts invalid inputs, and provides a clear character counter (e.g. `0/40`), acting as proactive inline validation without extra code.
+
+## 2024-06-25 - Async Feedback for Cached API Calls Triggered by UI Interactions
+**Learning:** Synchronous external API calls (like Nominatim reverse geocoding) triggered indirectly by UI interactions (like clicking a location on a map) can cause the app to hang silently for several seconds on cache misses, confusing users about whether their interaction was registered.
+**Action:** When using `@st.cache_data` to memoize external API calls that are triggered by user interaction, explicitly opt-in to visual feedback by setting `show_spinner="Descriptive message..."`. This ensures the UI remains responsive and transparent during cache misses while preserving instant execution on cache hits.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -79,7 +79,7 @@ def _load_api_key() -> Optional[str]:
     return None
 
 
-@st.cache_data(show_spinner=False)
+@st.cache_data(show_spinner="📍 Reverse geocoding...")
 def get_location_name(lat: float, lon: float) -> str:
     """
     Reverse geocodes the given latitude and longitude using OpenStreetMap Nominatim API.
@@ -156,7 +156,10 @@ def main():
             api_key = api_key_override
             api_key_source = "user"
             if len(api_key.strip()) != 40:
-                st.warning("User API key loaded, but it is not 40 characters long. NREL keys are typically exactly 40 characters.", icon="⚠️")
+                st.warning(
+                    "User API key loaded, but it is not 40 characters long. NREL keys are typically exactly 40 characters.",
+                    icon="⚠️",
+                )
             else:
                 st.success("User API key loaded.", icon="✅")
         elif default_api_key:
@@ -248,6 +251,7 @@ def main():
             value="tmy",
             placeholder="e.g., 2012, tmy, tmy-2024",
             help="A specific year (>=1998) or a TMY identifier like 'tmy' or 'tmy-2024'",
+            max_chars=15,
         )
 
     current_year = datetime.now().year

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ wheels = [
 
 [[package]]
 name = "nrel-psm3-2-epw"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
* 💡 **What**: 
  1. Enabled `show_spinner="📍 Reverse geocoding..."` on the cached `get_location_name` API call.
  2. Added a `max_chars=15` visual constraint to the Year text input.
* 🎯 **Why**: 
  1. When users click the map to select a new location, the reverse geocoding API call can take a few seconds on a cache miss, making the app appear hung. Enabling the spinner provides immediate visual feedback. 
  2. The Year input had no visual length constraint, allowing invalid giant strings to be pasted. `max_chars=15` automatically adds a helpful character counter and limits invalid inputs.
* 📸 **Before/After**: See attached screenshots in test execution.
* ♿ **Accessibility**: Provides immediate visual context and constraints to inputs and prevents the perception of application freezing for keyboard and mouse users alike.

---
*PR created automatically by Jules for task [11238222673988586052](https://jules.google.com/task/11238222673988586052) started by @kastnerp*