### PR TITLE
🎨 Palette: Add character limit to location text input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -46,3 +46,7 @@
 ## 2024-06-25 - Async Feedback for Cached API Calls Triggered by UI Interactions
 **Learning:** Synchronous external API calls (like Nominatim reverse geocoding) triggered indirectly by UI interactions (like clicking a location on a map) can cause the app to hang silently for several seconds on cache misses, confusing users about whether their interaction was registered.
 **Action:** When using `@st.cache_data` to memoize external API calls that are triggered by user interaction, explicitly opt-in to visual feedback by setting `show_spinner="Descriptive message..."`. This ensures the UI remains responsive and transparent during cache misses while preserving instant execution on cache hits.
+
+## 2026-03-22 - Visual Constraints on Text Inputs Used for Filenames
+**Learning:** In Streamlit applications, string inputs like "Location Name" that are eventually used to generate output filenames can cause confusion or errors if users input excessively long or malformed strings. While backend validation handles empty strings, unbounded text fields do not signal the expected input format visually.
+**Action:** When capturing free-text input destined for filenames or external systems, consistently enforce sensible constraints using `max_chars` on `st.text_input()`. This immediately displays a character counter in the UI, gently guiding users and implicitly preventing egregiously long strings before submission, serving as proactive inline validation without needing extra custom code.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -241,6 +241,7 @@ def main():
             value=default_location,
             placeholder="e.g., Atlanta",
             help="A descriptive name for the location, used to generate the output filename",
+            max_chars=60,
         )
         location_is_valid = bool(str(location).strip())
         if not location_is_valid:


### PR DESCRIPTION
💡 **What:** Added a `max_chars=60` constraint to the "Location Name" text input in the Streamlit app.
🎯 **Why:** The "Location Name" string is directly used to generate the name of the downloaded EPW file. Previously, there was no UI constraint on the length of this string, meaning users could inadvertently paste or type an excessively long string, which would result in OS file-system errors or an ugly, truncated downloaded file. Adding `max_chars` implicitly enforces this constraint and provides users with a helpful character counter inline, preventing the issue at the source.
📸 **Before/After:** The text input now displays a visual error indicator and prevents typing when reaching the 60-character limit.
♿ **Accessibility:** This is a proactive UX constraint that reduces potential user errors and communicates limitations implicitly, removing the need for post-submission validation errors.

---
*PR created automatically by Jules for task [1344179376662709415](https://jules.google.com/task/1344179376662709415) started by @kastnerp*