### PR TITLE
🎨 Palette: Dynamically update API Key input label based on required state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -50,3 +50,7 @@
 ## 2026-03-22 - Visual Constraints on Text Inputs Used for Filenames
 **Learning:** In Streamlit applications, string inputs like "Location Name" that are eventually used to generate output filenames can cause confusion or errors if users input excessively long or malformed strings. While backend validation handles empty strings, unbounded text fields do not signal the expected input format visually.
 **Action:** When capturing free-text input destined for filenames or external systems, consistently enforce sensible constraints using `max_chars` on `st.text_input()`. This immediately displays a character counter in the UI, gently guiding users and implicitly preventing egregiously long strings before submission, serving as proactive inline validation without needing extra custom code.
+
+## 2024-06-26 - Dynamic API Key Labeling
+**Learning:** In Streamlit apps with default credentials, labelling an override input as 'optional' can be misleading if no default key is actually configured or present, confusing users as to whether input is required.
+**Action:** Dynamically update form labels and help text based on the presence of required configurations, indicating when an input is 'required' versus 'optional', providing a clearer user experience.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -144,11 +144,19 @@ def main():
     api_key_source = "none"
 
     with st.expander("🔑 API Key Configuration", expanded=not bool(default_api_key)):
+        label = (
+            "Provide your own NREL API key (optional):" if default_api_key else "Provide your NREL API key (required):"
+        )
+        help_text = (
+            "Overrides the default API key if provided."
+            if default_api_key
+            else "An NREL API key is strictly required to request data."
+        )
         api_key_override = st.text_input(
-            "Provide your own NREL API key (optional):",
+            label,
             value="",
             type="password",
-            help="Overrides the default API key if provided.",
+            help=help_text,
             max_chars=40,
         )
 


### PR DESCRIPTION
💡 **What**: The API key configuration section in the UI now dynamically updates its label and help text. If no default API key is present on the system/server, the label will display as "Provide your NREL API key (required):". If a default key *is* present, it will display as "Provide your own NREL API key (optional):" as before.
🎯 **Why**: Previously, the input was statically labeled as "(optional)" even if no default API key was configured for the deployment. This caused user confusion, making them think they didn't need a key to proceed. By dynamically labeling the field as required or optional, users get immediate, clear instruction on what is necessary to run the tool.
📸 **Before/After**: See frontend verification screenshot.
♿ **Accessibility**: Improves cognitive accessibility by providing clear, context-aware instructions for form inputs, adhering to UX standards for clear labeling.

---
*PR created automatically by Jules for task [2115644993085277061](https://jules.google.com/task/2115644993085277061) started by @kastnerp*