### PR TITLE
🎨 Palette: Add explicit page config for browser tab context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -54,3 +54,7 @@
 ## 2024-06-26 - Dynamic API Key Labeling
 **Learning:** In Streamlit apps with default credentials, labelling an override input as 'optional' can be misleading if no default key is actually configured or present, confusing users as to whether input is required.
 **Action:** Dynamically update form labels and help text based on the presence of required configurations, indicating when an input is 'required' versus 'optional', providing a clearer user experience.
+
+## 2024-07-10 - Explicit Browser Tab Titles and Icons via Page Config
+**Learning:** By default, a Streamlit application displays a generic "Streamlit" label and logo in the browser tab. For users who work with many browser tabs open, this generic presentation makes the application hard to find and feels unpolished, negatively impacting the user experience and task efficiency.
+**Action:** Always call `st.set_page_config` as the very first Streamlit command in the application's entry point to explicitly set a contextually relevant `page_title` and `page_icon`. This ensures the application is easily identifiable among other open browser tabs and presents a professional, cohesive brand experience.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -131,6 +131,7 @@ def get_map():
 
 
 def main():
+    st.set_page_config(page_title="NREL to EPW", page_icon="☀️")
     st.markdown(f"""
     # NREL-PSM3-2-EPW  `v{__version__}`
 


### PR DESCRIPTION
💡 **What:** Added `st.set_page_config(page_title="NREL to EPW", page_icon="☀️")` to the `main()` entry point of the application.
🎯 **Why:** Streamlit apps default to displaying a generic "Streamlit" title and logo in the user's browser tab. This makes the application hard to find and distinguish when a user has multiple tabs open, creating a frustrating navigation experience. By explicitly setting a contextually relevant title and icon, the application feels more polished, branded, and easier to locate.
📸 **Before/After:** The browser tab now explicitly says "NREL to EPW" and features a sun emoji instead of the default generic branding.
♿ **Accessibility:** This improves overall usability for users managing many open tabs by providing clear, distinct tab labels.

---
*PR created automatically by Jules for task [3266959766459024466](https://jules.google.com/task/3266959766459024466) started by @kastnerp*