### PR TITLE
🎨 Palette: Add fine-grained step controls to coordinate inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -58,3 +58,7 @@
 ## 2024-07-10 - Explicit Browser Tab Titles and Icons via Page Config
 **Learning:** By default, a Streamlit application displays a generic "Streamlit" label and logo in the browser tab. For users who work with many browser tabs open, this generic presentation makes the application hard to find and feels unpolished, negatively impacting the user experience and task efficiency.
 **Action:** Always call `st.set_page_config` as the very first Streamlit command in the application's entry point to explicitly set a contextually relevant `page_title` and `page_icon`. This ensures the application is easily identifiable among other open browser tabs and presents a professional, cohesive brand experience.
+
+## 2024-03-24 - Fine-Grained Stepping for Coordinate Inputs
+**Learning:** By default, Streamlit assigns a step size of 0.01 to float `number_input` components unless specified otherwise. For geographic coordinates (latitude/longitude), 0.01 degrees represents a massive physical distance (~1.1 kilometers). This renders the native up/down stepper controls (and keyboard up/down arrows) practically useless for making fine location adjustments, forcing users to manually type out decimals.
+**Action:** Always explicitly define a small, context-appropriate `step` value (e.g., `step=0.0001`, approx 11 meters) for numeric inputs representing GPS coordinates. This ensures the native UI stepper controls and keyboard arrows provide meaningful, fine-grained adjustments, improving accessibility and overall form usability.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -231,6 +231,7 @@ def main():
             max_value=90.0,
             value=float(default_lat),
             format="%.4f",
+            step=0.0001,
             help="Latitude of the location in decimal degrees (e.g., 33.770)",
         )
     with col2:
@@ -240,6 +241,7 @@ def main():
             max_value=180.0,
             value=float(default_lon),
             format="%.4f",
+            step=0.0001,
             help="Longitude of the location in decimal degrees (e.g., -84.3824)",
         )
 


### PR DESCRIPTION
### 💡 What
Explicitly set `step=0.0001` on the `st.number_input` fields for Latitude and Longitude.

### 🎯 Why
By default, `st.number_input` for floats increments/decrements by `0.01` (roughly 1.1km or 0.7 miles for geographic coordinates). This made the native UI stepper arrows and keyboard up/down arrows practically useless for users trying to make fine positional adjustments.

### 📸 Before/After
*   **Before:** Clicking the up arrow on Latitude changed `33.7700` to `33.7800` (moving ~1.1km).
*   **After:** Clicking the up arrow on Latitude changes `33.7700` to `33.7701` (moving ~11 meters), enabling precise micro-adjustments directly from the input field.

### ♿ Accessibility
This change dramatically improves keyboard accessibility. Users navigating via keyboard can now accurately dial in coordinate positions using the Up/Down arrow keys, reducing the need to rely exclusively on precise mouse clicks on the map or manual text entry.

---
*PR created automatically by Jules for task [3426884472935254927](https://jules.google.com/task/3426884472935254927) started by @kastnerp*