### PR TITLE
🎨 Palette: Remove directional language from UI instructions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -70,3 +70,7 @@
 ## 2026-03-26 - Full-Width Action Buttons for Better Mobile UX
 **Learning:** Default-sized primary action buttons (like "Submit" or "Download") in Streamlit applications often result in small touch targets, making them difficult to interact with on mobile devices and causing them to get visually lost underneath large form inputs on desktop views.
 **Action:** Always use `use_container_width=True` on primary action buttons (like `st.button` and `st.download_button`) that complete a section or form. This explicitly increases the touch target size across all devices, significantly improving mobile usability and providing a clearer visual hierarchy at the end of a user flow.
+
+## 2026-03-27 - Avoid Directional Language in Error and Info Messages
+**Learning:** Using directional language like "above" or "below" in UI instructions or error messages is an accessibility anti-pattern (violating WCAG 1.3.3 Sensory Characteristics). Screen reader users navigate linearly, not spatially, and cannot perceive "above" or "below". Furthermore, visual layout changes in responsive designs can render directional instructions inaccurate.
+**Action:** Always provide explicit, context-independent instructions. Instead of saying "Please provide an API key above", use descriptive references to the specific section or component, such as "Please provide an API key in the 'API Key Configuration' section".

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -183,7 +183,7 @@ def main():
             else:
                 st.warning("Default API key loaded (Unverified).", icon="⚠️")
         else:
-            st.error("No API key loaded. Please provide one above.", icon="🛑")
+            st.error("No API key loaded. Please provide one in the API Key Configuration section.", icon="🛑")
 
     st.markdown("### Location & Time Details")
 
@@ -297,8 +297,8 @@ def main():
             st.error(year_warning, icon="⚠️")
 
     if not api_key:
-        button_help = "Please provide an API key above to enable this button"
-        st.warning("Please provide an API key in the 'API Key Configuration' section above to request data.", icon="🔑")
+        button_help = "Please provide an API key in the configuration section to enable this button"
+        st.warning("Please provide an API key in the 'API Key Configuration' section to request data.", icon="🔑")
     elif not year_is_valid:
         button_help = year_warning
     elif not location_is_valid:
@@ -335,13 +335,15 @@ def main():
             except Exception as exc:
                 st.error(f"Request failed: {exc}")
                 if api_key_source == "default":
-                    st.info("If this failure is related to the default API key, enter your own key above and retry.")
+                    st.info(
+                        "If this failure is related to the default API key, enter your own key in the API Key Configuration section and retry."
+                    )
                 st.stop()
 
         if os.path.exists(file_name):
             with open(file_name, "rb") as f:
                 s = f.read()
-                st.success("Data successfully processed! Click below to download.")
+                st.success("Data successfully processed! Your EPW file is ready for download.")
                 st.download_button(
                     label="Download EPW",
                     data=s,


### PR DESCRIPTION
**What:**
Replaced spatial directional language ("above", "below") in error, warning, success messages, and tooltips with context-independent references (e.g., "in the API Key Configuration section").

**Why:**
Directional language relies on visual layout, which can change in responsive designs. This improves clarity and accessibility for all users.

**Before/After:**
*   Before: "No API key loaded. Please provide one above."
*   After: "No API key loaded. Please provide one in the API Key Configuration section."
*   Before: "Data successfully processed! Click below to download."
*   After: "Data successfully processed! Your EPW file is ready for download."

**Accessibility:**
This resolves a WCAG 1.3.3 Sensory Characteristics violation. Screen reader users navigate linearly, not spatially, and cannot perceive concepts like "above" or "below", making the previous instructions confusing or inaccessible. Explicitly referencing the component/section improves the experience.

---
*PR created automatically by Jules for task [15983817482082073740](https://jules.google.com/task/15983817482082073740) started by @kastnerp*