### PR TITLE
Update NREL domain to developer.nlr.gov

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -136,7 +136,7 @@ def main():
     # NREL-PSM3-2-EPW  `v{__version__}`
 
     This script converts climate data from NREL to the EnergyPlus EPW format.
-    If you do not have an API key, please [request an NREL API key](https://developer.nrel.gov/signup).
+    If you do not have an API key, please [request an NREL API key](https://developer.nlr.gov/signup).
     """)
 
     # API Key Handling

--- a/nrel_psm3_2_epw/constants.py
+++ b/nrel_psm3_2_epw/constants.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-GOES_AGGREGATED_URL = "https://developer.nrel.gov/api/nsrdb/v2/solar/nsrdb-GOES-aggregated-v4-0-0-download.csv"
-GOES_TMY_URL = "https://developer.nrel.gov/api/nsrdb/v2/solar/nsrdb-GOES-tmy-v4-0-0-download.csv"
+GOES_AGGREGATED_URL = "https://developer.nlr.gov/api/nsrdb/v2/solar/nsrdb-GOES-aggregated-v4-0-0-download.csv"
+GOES_TMY_URL = "https://developer.nlr.gov/api/nsrdb/v2/solar/nsrdb-GOES-tmy-v4-0-0-download.csv"
 
 DEFAULT_HEADERS = {
     "LOCATION": [

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ wheels = [
 
 [[package]]
 name = "nrel-psm3-2-epw"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Update NREL domain from developer.nrel.gov to developer.nlr.gov

Updated all hardcoded URLs pointing to developer.nrel.gov to use
developer.nlr.gov to ensure service continuity ahead of the April 30,
2026 deadline.

---
*PR created automatically by Jules for task [6825166294154430686](https://jules.google.com/task/6825166294154430686) started by @kastnerp*