### PR TITLE
🎨 Palette: Improve onboarding callouts and validation clarity

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -98,3 +98,7 @@
 ## 2026-04-04 - Avoiding Inaccessible Tooltips
 **Learning:** In Streamlit, instructions passed via the `help` parameter of input components are rendered as hover-only tooltips. These are completely inaccessible to users on mobile and touch devices, meaning critical context or formatting rules are hidden.
 **Action:** Remove the `help` parameters and move critical instructions into explicit `st.caption` elements placed immediately below the inputs.
+
+## 2024-05-24 - Conditional Onboarding Callouts
+**Learning:** Returning users experience visual fatigue and "banner blindness" when presented with static onboarding instructions (like API key signup links) on every visit.
+**Action:** Extract static onboarding links from general descriptions into visually distinct callouts (e.g., `st.info` with an icon) and conditionally display them *only* when the required configuration (e.g., a default API key) is missing. This reduces clutter for returning users while providing clear guidance for new users.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -136,11 +136,14 @@ def main():
     # NREL-PSM3-2-EPW  `v{__version__}`
 
     This script converts climate data from NREL to the EnergyPlus EPW format.
-    If you do not have an API key, please [request an NREL API key](https://developer.nlr.gov/signup).
     """)
 
     # API Key Handling
     default_api_key = _load_api_key()
+
+    if not default_api_key:
+        st.info("👋 **First time here?** You'll need an API key to download data. [Request an NREL API key](https://developer.nlr.gov/signup) for free.", icon="💡")
+
     api_key = ""
     api_key_source = "none"
 
@@ -259,7 +262,7 @@ def main():
         st.caption("📝 *Used to generate the output filename.*")
         location_is_valid = bool(str(location).strip())
         if not location_is_valid:
-            st.error("Please provide a location name.", icon="⚠️")
+            st.warning("A location name is required to generate the file.", icon="⚠️")
     with col4:
         year = st.text_input(
             "Year",
@@ -378,7 +381,7 @@ def main():
                 icon="📊",
             )
         else:
-            st.error("Please make sure that NREL is able to deliver data for the location and year your provided.")
+            st.error("Please make sure that NREL is able to deliver data for the location and year you provided.")
         st.stop()
 
 


### PR DESCRIPTION
💡 What: Extracted the API key signup link from the general markdown description into a visually distinct `st.info` callout that only appears when a default API key is not configured. Changed the immediate missing location name `st.error` to a softer `st.warning`. Fixed a typo in the final data delivery error message.
🎯 Why: Returning users experience visual fatigue ("banner blindness") when presented with static onboarding instructions on every visit. Conditionally hiding these links reduces clutter for returning users while providing better, highlighted guidance for new users. Using a warning instead of an error for preliminary missing inputs creates a less aggressive user flow.
📸 Before/After: Visual changes were verified locally using Playwright screenshots. The new `st.info` callout provides a clear, highlighted box with an icon, and the validation feedback uses the yellow warning color instead of the red error color.
♿ Accessibility: The new conditional callout uses the `st.info` component which provides appropriate semantic structure and visual contrast compared to plain markdown text.

---
*PR created automatically by Jules for task [15242415948000224808](https://jules.google.com/task/15242415948000224808) started by @kastnerp*