### PR TITLE
🎨 Palette: Add explicit inline instruction to Location field

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -114,3 +114,7 @@
 ## 2026-04-05 - Dynamic Output Filename Previews
 **Learning:** Users often lack visibility into how their inputs will affect the generated file until after they initiate the download process, leading to uncertainty and potential errors.
 **Action:** Implement real-time dynamic previews of the expected output filename directly beneath the relevant input fields. This provides immediate feedback and sets clear expectations before the user commits to an action.
+
+## 2024-05-24 - Symmetrical Inline Guidance for Multi-Column Layouts
+**Learning:** When arranging form inputs in multi-column layouts (like `st.columns`), providing inline instructions (`st.caption`) for one field but not the adjacent field not only deprives the user of context but creates an unbalanced visual hierarchy.
+**Action:** Ensure symmetrical levels of inline guidance in multi-column layouts. If one column requires extensive explanation, provide at least a brief, helpful instruction for the adjacent column to maintain layout balance and improve overall form accessibility.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -266,6 +266,7 @@ def main():
             placeholder="e.g., Atlanta",
             max_chars=60,
         )
+        st.caption("A descriptive name for the location, used to generate the output filename.")
         filename_preview_placeholder = st.empty()
         location_is_valid = bool(str(location).strip())
         if not location_is_valid:


### PR DESCRIPTION
**💡 What:** Added explicit inline guidance (`st.caption`) beneath the "Location Name" input in `streamlit_app.py`, explaining that this value will be used to generate the output filename.
**🎯 Why:** To provide necessary context to the user about why this field is required and how it affects the application's output, improving overall form clarity. It also structurally balances the multi-column layout where the adjacent "Year" column already contained two captions.
**📸 Before/After:** Before, the "Location Name" input lacked instruction and caused the left column to look visibly shorter/unbalanced compared to the right column. After, the descriptive caption sets user expectations correctly and visually aligns the two form columns.
**♿ Accessibility:** Improves adherence to WCAG 3.3.2 (Labels or Instructions) by providing clear, context-independent instructions directly adjacent to the required input field, rather than hiding this context in a tooltip or omitting it entirely.

---
*PR created automatically by Jules for task [16234176400303835302](https://jules.google.com/task/16234176400303835302) started by @kastnerp*