### PR TITLE
🎨 Palette: Improve heading hierarchy and visual flow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility Heading Hierarchy & State Preview Placement
+**Learning:** Avoid skipping heading levels (e.g., from `h1` to `h3`) as it breaks WCAG 1.3.1 guidelines and confuses screen reader users who rely on heading structure for document navigation. Furthermore, when a visual preview (like an output filename) depends on multiple inputs spread across columns, placing it inside one of the columns creates a disjointed mental model and breaks visual flow on mobile layouts.
+**Action:** Always maintain sequential heading levels (`h1` -> `h2` -> `h3`). Always place dependent state previews chronologically *after* all the inputs that affect it, ensuring a clear summary before the primary action button.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -195,7 +195,7 @@ def main():
         else:
             st.warning("No API key loaded. Please provide one in the API Key Configuration section.", icon="⚠️")
 
-    st.markdown("### Location & Time Details")
+    st.markdown("## Location & Time Details")
 
     # Show a map to pick lat/lon
     st.write("Select a location on the map, or enter coordinates manually:")
@@ -267,7 +267,6 @@ def main():
             max_chars=60,
         )
         st.caption("A descriptive name for the location, used to generate the output filename.")
-        filename_preview_placeholder = st.empty()
         location_is_valid = bool(str(location).strip())
         if not location_is_valid:
             st.warning("A location name is required to generate the file.", icon="⚠️")
@@ -289,7 +288,7 @@ def main():
     # Dynamic filename preview
     safe_loc = re.sub(r"[^a-zA-Z0-9]", "_", str(location).strip()) if str(location).strip() else "Unnamed"
     preview_name = f"{safe_loc}_{lat:.2f}_{lon:.2f}_{year_str or 'YYYY'}_{current_year}.epw"
-    filename_preview_placeholder.caption(f"📝 *Output filename:* `{preview_name}`")
+    st.caption(f"📝 *Output filename:* `{preview_name}`")
 
     # Basic Year Validation
     if not year_str:


### PR DESCRIPTION
💡 What: Changed the `### Location & Time Details` heading to `## Location & Time Details` and moved the output filename preview out of the column layout to the bottom of the section.
🎯 Why: Skipped heading levels confuse screen readers (WCAG 1.3.1). Additionally, the filename preview was nested in `col3` despite depending on inputs from all four columns, breaking the visual flow and responsive mobile layout. 
📸 Before/After: Visual hierarchy is now preserved on mobile devices and screen readers interpret semantic heading trees sequentially.
♿ Accessibility: Ensures document outline conforms to WCAG 1.3.1 (Info and Relationships) and improves logical form order.

---
*PR created automatically by Jules for task [9200088913591375438](https://jules.google.com/task/9200088913591375438) started by @kastnerp*