### PR TITLE
🎨 Palette: Full-width validation feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility Heading Hierarchy & State Preview Placement
 **Learning:** Avoid skipping heading levels (e.g., from `h1` to `h3`) as it breaks WCAG 1.3.1 guidelines and confuses screen reader users who rely on heading structure for document navigation. Furthermore, when a visual preview (like an output filename) depends on multiple inputs spread across columns, placing it inside one of the columns creates a disjointed mental model and breaks visual flow on mobile layouts.
 **Action:** Always maintain sequential heading levels (`h1` -> `h2` -> `h3`). Always place dependent state previews chronologically *after* all the inputs that affect it, ensuring a clear summary before the primary action button.
+## 2024-05-25 - Form Validation Layout in Columns
+**Learning:** Rendering text-heavy validation messages (like `st.warning` or `st.error`) inside specific layout columns (e.g., `st.columns`) squishes the text. This not only creates an unbalanced visual hierarchy compared to sibling columns but severely degrades readability on mobile devices where columns become exceptionally narrow before collapsing.
+**Action:** Always extract and render dynamic form validation feedback chronologically outside and below the column containers, ensuring they span full-width directly above the primary submission action.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -268,8 +268,6 @@ def main():
         )
         st.caption("A descriptive name for the location, used to generate the output filename.")
         location_is_valid = bool(str(location).strip())
-        if not location_is_valid:
-            st.warning("A location name is required to generate the file.", icon="⚠️")
     with col4:
         year = st.text_input(
             "Year (required)",
@@ -312,9 +310,12 @@ def main():
             year_is_valid = False
             year_warning = "Year must be a numeric year (>=1998) or a TMY name like tmy or tmy-2024."
 
+    # Full-width validation warnings below inputs
+    if not location_is_valid:
+        st.warning("A location name is required to generate the file.", icon="⚠️")
+
     if not year_is_valid:
-        with col4:
-            st.warning(year_warning, icon="⚠️")
+        st.warning(year_warning, icon="⚠️")
 
     if not api_key:
         button_help = "Please provide an API key in the configuration section to enable this button"


### PR DESCRIPTION
**What**:
Moved the `st.warning` messages for form validation (Location and Year inputs) outside of their respective layout columns (`col3` and `col4`) and placed them sequentially above the primary "Request from NLR" button.

**Why**:
Rendering text-heavy validation messages inside narrow layout columns squishes the text, creating an unbalanced visual hierarchy compared to sibling columns. This severely degrades readability and visual flow on mobile devices where columns become exceptionally narrow before wrapping. Moving them outside ensures they span full-width.

**Before/After**:
- *Before*: Warnings appeared disjointed, squeezed tightly under individual inputs, misaligning with the wider API key warning layout above.
- *After*: Warnings span the full width of the container sequentially below the inputs and immediately before the action button, maintaining a consistent, clear summary layout for the user before submission.

**Accessibility**:
Improves visual readability and information hierarchy (WCAG 1.3.1 Info and Relationships) by grouping critical validation states linearly right before the focus sequence reaches the submit button. Prevents cognitive load caused by irregular visual placement.

---
*PR created automatically by Jules for task [17925917674607352390](https://jules.google.com/task/17925917674607352390) started by @kastnerp*