### PR TITLE
🎨 Palette: Add visual symmetry to layout and future-year form validation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-25 - Form Validation Layout in Columns
 **Learning:** Rendering text-heavy validation messages (like `st.warning` or `st.error`) inside specific layout columns (e.g., `st.columns`) squishes the text. This not only creates an unbalanced visual hierarchy compared to sibling columns but severely degrades readability on mobile devices where columns become exceptionally narrow before collapsing.
 **Action:** Always extract and render dynamic form validation feedback chronologically outside and below the column containers, ensuring they span full-width directly above the primary submission action.
+## 2024-06-14 - Visual Symmetry in Multi-column Layouts & Proactive Future Validation
+**Learning:** In Streamlit multi-column layouts, providing instructions for one column but not another creates an unbalanced visual hierarchy and breaks form consistency. Furthermore, missing proactive validation for future dates leads to confusing downstream API errors.
+**Action:** Always ensure symmetrical levels of inline guidance (e.g., `st.caption`) beneath inputs across adjacent columns. Always provide proactive inline validation for impossible inputs (like future years) to prevent unnecessary network requests and confusing errors.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -267,6 +267,7 @@ def main():
             max_chars=60,
         )
         st.caption("A descriptive name for the location, used to generate the output filename.")
+        st.caption("💡 *Auto-updates when you select a new location on the map.*")
         location_is_valid = bool(str(location).strip())
     with col4:
         year = st.text_input(
@@ -294,11 +295,11 @@ def main():
         year_warning = "A year or TMY identifier is required."
     elif year_str.isdigit():
         year_int = int(year_str)
-        if year_int in (current_year, current_year - 1):
+        if year_int >= current_year - 1:
             year_is_valid = False
             year_warning = (
-                f"NLR does not provide data for the current year {year}. "
-                f"It is also unlikely that there is data availability for {year_int - 1}."
+                f"NLR does not provide data for the year {year}. "
+                f"Data is typically only available up to {current_year - 2}."
             )
         elif year_int < MIN_YEAR:
             year_is_valid = False


### PR DESCRIPTION
### 💡 What
Added a helpful `st.caption` beneath the "Location Name" input and updated the year validation logic to proactively catch any future years (`>= current_year - 1`) instead of just exactly the current or previous year. Also updated `.Jules/palette.md` with these learnings.

### 🎯 Why
To balance the visual layout across adjacent columns (the Year column had two captions, while the Location column only had one), which makes the form look more consistent. Additionally, the improved validation catches impossible future inputs (like "2030") immediately and provides an inline warning, preventing the application from sending a doomed network request and failing with a confusing API error.

### 📸 Before/After
- **Before**: The Location input column looked visually lighter/shorter than the Year column. Entering a future year (e.g., 2030) would silently pass frontend validation, attempt an API request, and result in an error.
- **After**: The columns are visually balanced. Entering a future year immediately triggers an inline `st.warning` indicating that data is typically only available up to `current_year - 2`.

### ♿ Accessibility
Improves usability by providing immediate, context-aware inline feedback for impossible inputs rather than waiting for an action button click or a downstream error, adhering to proactive validation principles. The added caption provides clear, unobtrusive instructions about the map interaction behavior.

---
*PR created automatically by Jules for task [13668552525736590435](https://jules.google.com/task/13668552525736590435) started by @kastnerp*