### PR TITLE
🎨 Palette: Improve button feedback and actionable help

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,7 @@
 ## 2025-02-13 - Graceful Error Degradation & Semantic Typography
 **Learning:** Exposing raw Python exception strings (which often contain verbose URLs, stack traces, and massive JSON payloads) directly in `st.error` violates heuristic evaluation principles for user-friendly error messages and overwhelms non-technical users. Furthermore, using raw markdown headings like `st.markdown("# Title")` injects semantic HTML `H1` tags but often entangles irrelevant metadata (like version strings), creating confusing navigation for screen readers.
 **Action:** Always provide concise, user-centric error summaries in `st.error` and hide technical details (like raw exception strings) behind a collapsed `st.expander` for developers. Always use dedicated semantic functions like `st.title()` and `st.caption()` to cleanly separate primary page structure from secondary metadata.
+
+## 2025-02-14 - Button Tooltips on Mobile
+**Learning:** Hiding critical validation instructions inside a button's `help` parameter (tooltips) makes them completely inaccessible on mobile devices, preventing users from understanding why a button is disabled.
+**Action:** Avoid relying on the `help` parameter for critical disabled-state instructions. Always provide explicit, persistently visible text (like `st.warning` or `st.caption`) in the main UI flow.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -155,9 +155,9 @@ def main():
     with st.expander("🔑 API Key Configuration", expanded=not bool(default_api_key)):
         label = "Provide your own NLR API key (optional)" if default_api_key else "Provide your NLR API key (required)"
         help_text = (
-            "Overrides the default API key if provided."
+            f"Overrides the default API key if provided. You can [request a free NLR API key]({DEVELOPER_SIGNUP_URL}) if needed."
             if default_api_key
-            else "An NLR API key is strictly required to request data."
+            else f"An NLR API key is strictly required to request data. You can [request a free NLR API key]({DEVELOPER_SIGNUP_URL})."
         )
         api_key_override = st.text_input(
             label,
@@ -311,13 +311,11 @@ def main():
             year_is_valid = False
             year_warning = (
                 f"NLR does not provide data for the year {year}. "
-                f"Data is typically only available up to {current_year - 2}."
+                f"Data is typically only available up to {current_year - 2}. Please enter an earlier year."
             )
         elif year_int < MIN_YEAR:
             year_is_valid = False
-            year_warning = (
-                f"NLR does not provide data for the year {year}. The earliest year data is available for is {MIN_YEAR}."
-            )
+            year_warning = f"NLR does not provide data for the year {year}. The earliest year data is available for is {MIN_YEAR}. Please enter a more recent year."
     else:
         if not year_str.lower().startswith(("tmy", "tgy", "tdy")):
             year_is_valid = False
@@ -330,20 +328,15 @@ def main():
     if not year_is_valid:
         st.warning(year_warning, icon="⚠️")
 
+    if not location_is_valid:
+        st.warning("Please provide a valid location name.", icon="📍")
+
     if not api_key:
-        button_help = "Please provide an API key in the configuration section to enable this button"
         st.warning("Please provide an API key in the 'API Key Configuration' section to request data.", icon="🔑")
-    elif not year_is_valid:
-        button_help = year_warning
-    elif not location_is_valid:
-        button_help = "Please provide a valid location name."
-    else:
-        button_help = "Initiates request to NLR API to download EPW file"
 
     if st.button(
         "Request from NLR",
         type="primary",
-        help=button_help,
         disabled=not bool(api_key) or not year_is_valid or not location_is_valid,
         icon=":material/cloud_download:",
         use_container_width=True,
@@ -372,7 +365,8 @@ def main():
                     st.code(str(exc), language="text")
                 if api_key_source == "default":
                     st.info(
-                        "If this failure is related to the default API key, enter your own key in the API Key Configuration section and retry."
+                        "If this failure is related to the default API key, enter your own key in the API Key Configuration section and retry.",
+                        icon="💡",
                     )
                 st.stop()
 


### PR DESCRIPTION
### 💡 What
- Removed the dynamic `button_help` logic from the primary `st.button` and instead render all validation errors (`year_warning`, `location_is_valid`, and missing API key) as explicitly visible `st.warning` banners in the main UI flow above the button.
- Appended actionable instructions to the year validation limits (e.g., "Please enter an earlier year").
- Added a markdown link to the `DEVELOPER_SIGNUP_URL` within the API key configuration help text for users who don't have a default key.
- Added a helpful lightbulb icon (`💡`) to the default API key fallback suggestion.

### 🎯 Why
Streamlit's `help` parameter renders a hover tooltip. On mobile devices or touch screens, this is impossible to interact with on a disabled button, leading to a frustrating experience where a user cannot determine *why* they can't proceed. Moving this critical feedback into persistently visible UI elements solves this.

### 📸 Before/After
**Before:** Validation warnings preventing a download were hidden in a hover tooltip on the download button.
**After:** Clear, actionable warnings are shown directly above the disabled button.

### ♿ Accessibility
Addresses a critical mobile accessibility issue by not hiding disabled state instructions inside hover-only tooltips. Ensures all validation logic provides a persistently visible, context-independent reason for why the user is blocked.

---
*PR created automatically by Jules for task [6250777848032199794](https://jules.google.com/task/6250777848032199794) started by @kastnerp*