### PR TITLE
🎨 Palette: Add placeholders to coordinate inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-02-20 - Context-Aware Troubleshooting and Reducing Visual Clutter
 **Learning:** Duplicate error messages or warnings clutter the UI and increase cognitive load. Furthermore, generic troubleshooting guidance fails to assist users who are in specific states (e.g., using a custom API key vs. a default one). Providing irrelevant advice based on the wrong context leads to user frustration.
 **Action:** Always verify that form validation messages are uniquely presented. Always tailor troubleshooting advice in error messages based on the active user context (e.g., advising custom API key users to check their portal instead of advising them to enter a custom key).
+## 2025-02-20 - Placeholder Context in Number Inputs
+**Learning:** Using `st.number_input` without providing `placeholder` text requires the user to infer the expected formatting of the required data. This increases cognitive load, especially when handling specific numerical patterns like coordinates.
+**Action:** Always provide explicit `placeholder` text (e.g., `placeholder="33.7700"`) for numeric inputs where possible to immediately demonstrate the expected format and establish clear expectations before data entry.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -257,6 +257,7 @@ def main():
             key="input_lat",
             format="%.4f",
             step=0.0001,
+            placeholder="33.7700",
         )
         st.caption("Latitude of the location in decimal degrees (e.g., 33.770)")
     with col2:
@@ -267,6 +268,7 @@ def main():
             key="input_lon",
             format="%.4f",
             step=0.0001,
+            placeholder="-84.3824",
         )
         st.caption("Longitude of the location in decimal degrees (e.g., -84.3824)")
 


### PR DESCRIPTION
💡 **What:** Added `placeholder` parameters to the Latitude and Longitude `st.number_input` widgets.
🎯 **Why:** To provide clear, immediate expectations for the numerical format of coordinates before user entry, reducing cognitive load and errors.
📸 **Before/After:** The coordinate fields previously showed up entirely empty. They now display faint grey text ("33.7700" and "-84.3824") that disappears when typing.
♿ **Accessibility:** Improves WCAG 3.3.2 (Labels or Instructions) compliance by offering an in-context example of expected data formatting without relying purely on external documentation.

---
*PR created automatically by Jules for task [8656687197470566834](https://jules.google.com/task/8656687197470566834) started by @kastnerp*