### PR TITLE
🎨 Palette: Proactively expand API configuration on default key failure

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -35,3 +35,6 @@
 ## 2025-06-27 - Actionable Instructions for State-based Warnings
 **Learning:** State-based warnings (like "Unverified" status) without actionable recovery instructions create dead-ends for users, leading to frustration. Simply stating that something is wrong isn't enough.
 **Action:** Always append specific, contextual troubleshooting steps (e.g., directing them to check the relevant configuration file or external service) to state-based warnings to facilitate user recovery and reduce cognitive load.
+## 2025-06-28 - Proactive Expansion of Validation Containers
+**Learning:** Hiding critical validation warnings inside collapsed containers (like `st.expander`) prevents users from noticing errors related to default configurations, leading to confusion when subsequent actions fail silently or unexpectedly.
+**Action:** Always proactively expand containers (e.g., setting `expanded=True`) if they contain an invalid state or a critical warning that requires user attention, ensuring the feedback is immediately visible.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -152,7 +152,14 @@ def main():
     api_key = ""
     api_key_source = "none"
 
-    with st.expander("🔑 API Key Configuration", expanded=not bool(default_api_key)):
+    # Proactively expand the configuration section if the default key is unverified
+    # so the user actually sees the warning instead of having it hidden.
+    is_default_key_unverified = False
+    if default_api_key:
+        if hashlib.sha256(default_api_key.strip().encode()).hexdigest() != VALID_API_KEY_HASH:
+            is_default_key_unverified = True
+
+    with st.expander("🔑 API Key Configuration", expanded=not bool(default_api_key) or is_default_key_unverified):
         label = "Provide your own NLR API key (optional)" if default_api_key else "Provide your NLR API key (required)"
         help_text = (
             f"Overrides the default API key if provided. You can [request a free NLR API key]({DEVELOPER_SIGNUP_URL}) if needed."


### PR DESCRIPTION
**💡 What:** 
Modified the `st.expander` logic in `app/streamlit_app.py` to proactively expand when a default API key is present but fails verification (invalid hash).

**🎯 Why:** 
Previously, if a user had an invalid API key in their `.streamlit/secrets.toml` file, the expander would stay collapsed. The warning message inside was completely hidden, leading to confusing silent failures or unexpected errors when clicking the download button.

**📸 Before/After:** 
Before: Expander stays closed, warning is hidden.
After: Expander opens automatically, prominently displaying the warning: `⚠️ Default API key loaded (Unverified)...`

**♿ Accessibility:** 
Improves error visibility (WCAG 3.3.1 Error Identification), ensuring users are immediately aware of configuration issues without having to manually hunt for them in collapsed menus.

---
*PR created automatically by Jules for task [5487330636984665684](https://jules.google.com/task/5487330636984665684) started by @kastnerp*