### PR TITLE
🎨 Palette: [UX] Forgiving API key formatting & reduced visual clutter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -38,3 +38,6 @@
 ## 2025-06-28 - Proactive Expansion of Validation Containers
 **Learning:** Hiding critical validation warnings inside collapsed containers (like `st.expander`) prevents users from noticing errors related to default configurations, leading to confusion when subsequent actions fail silently or unexpectedly.
 **Action:** Always proactively expand containers (e.g., setting `expanded=True`) if they contain an invalid state or a critical warning that requires user attention, ensuring the feedback is immediately visible.
+## 2025-02-23 - Postel's Law and Visual Clutter
+**Learning:** Failing to strip whitespace from sensitive inputs (like API keys) causes frustrating failures when users accidentally copy spaces. Additionally, duplicating validation warnings across the UI increases visual clutter and cognitive load.
+**Action:** Always apply Postel's Law by sanitizing inputs (e.g., `strip()`) before validation. Always ensure validation warnings are uniquely presented to minimize UI clutter.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -176,11 +176,11 @@ def main():
         st.caption(help_text)
 
         if api_key_override:
-            api_key = api_key_override
+            api_key = api_key_override.strip()
             api_key_source = "user"
-            if len(api_key.strip()) != 40:
+            if len(api_key) != 40:
                 st.warning(
-                    "User API key loaded, but it is not 40 characters long. NLR keys are typically exactly 40 characters.",
+                    "User API key loaded, but it is not 40 characters long. Please verify the entire key was copied correctly.",
                     icon="⚠️",
                 )
             else:
@@ -198,8 +198,6 @@ def main():
                     "Default API key loaded (Unverified). Please verify the key in your .streamlit/secrets.toml file.",
                     icon="⚠️",
                 )
-        else:
-            st.warning("No API key loaded. Please provide one in the API Key Configuration section.", icon="⚠️")
 
     st.header("Location & Time Details", divider="gray")
 


### PR DESCRIPTION
**What:** Stripped whitespace from user API keys during assignment and removed the duplicate "No API key" warning from inside the expander container. Improved key length warning text to be more actionable.
**Why:** Users frequently copy spaces when pasting keys, causing confusing silent failures if unstripped. Duplicate warnings increase cognitive load and clutter the UI.
**Before/After:** Removed redundant warning inside the expander. Updated error message text for incorrect key length.
**Accessibility:** Reduced visual clutter, helping screen reader users avoid duplicate and confusing announcements. Applied Postel's Law to make the interface more forgiving of accidental input errors.

---
*PR created automatically by Jules for task [4338420814355445154](https://jules.google.com/task/4338420814355445154) started by @kastnerp*