### PR TITLE
fix: re-enable request button for valid API keys

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,5 +1,4 @@
 import os
-import hashlib
 import re
 from datetime import datetime
 from importlib.metadata import version
@@ -14,6 +13,12 @@ __version__ = version("nlr-psm3-2-epw")
 
 from nlr_psm3_2_epw.assets import download_epw
 from nlr_psm3_2_epw.constants import DEVELOPER_DOCS_URL, DEVELOPER_SIGNUP_URL
+from nlr_psm3_2_epw.validation import (
+    API_KEY_LENGTH,
+    is_api_key_valid,
+    is_api_key_verified,
+    normalize_api_key,
+)
 
 # --- CONSTANTS ---
 ATTRIBUTES = (
@@ -152,12 +157,10 @@ def main():
     api_key = ""
     api_key_source = "none"
 
-    # Proactively expand the configuration section if the default key is unverified
-    # so the user actually sees the warning instead of having it hidden.
-    is_default_key_unverified = False
-    if default_api_key:
-        if hashlib.sha256(default_api_key.strip().encode()).hexdigest() != VALID_API_KEY_HASH:
-            is_default_key_unverified = True
+    # Verify the default key once, up front: it drives both the auto-expand
+    # behaviour below and the request-button validity further down.
+    default_key_verified = is_api_key_verified(default_api_key, VALID_API_KEY_HASH)
+    is_default_key_unverified = bool(default_api_key) and not default_key_verified
 
     with st.expander("🔑 API Key Configuration", expanded=not bool(default_api_key) or is_default_key_unverified):
         label = "Provide your own NLR API key (optional)" if default_api_key else "Provide your NLR API key (required)"
@@ -176,17 +179,15 @@ def main():
         st.caption(help_text)
 
         if api_key_override:
-            api_key = api_key_override.strip()
+            api_key = normalize_api_key(api_key_override)
             api_key_source = "user"
-            if len(api_key) == 40:
+            if len(api_key) == API_KEY_LENGTH:
                 st.success("User API key loaded.", icon="✅")
         elif default_api_key:
-            api_key = default_api_key
+            api_key = normalize_api_key(default_api_key)
             api_key_source = "default"
 
-            # Verify Hash
-            key_hash = hashlib.sha256(api_key.strip().encode()).hexdigest()
-            if key_hash == VALID_API_KEY_HASH:
+            if default_key_verified:
                 st.success("Default API key loaded (Verified).", icon="✅")
             else:
                 st.warning(
@@ -326,7 +327,11 @@ def main():
             year_is_valid = False
             year_warning = "Year must be a numeric year (>=1998) or a TMY name like tmy or tmy-2024."
 
-    api_key_is_valid = bool(api_key) and len(api_key) == 40
+    # A verified default key is usable regardless of length; any other key must
+    # be exactly API_KEY_LENGTH characters (whitespace already trimmed on load).
+    api_key_is_valid = is_api_key_valid(
+        api_key, is_verified=(api_key_source == "default" and default_key_verified)
+    )
 
     # Full-width validation warnings below inputs
     if not location_is_valid:

--- a/nlr_psm3_2_epw/validation.py
+++ b/nlr_psm3_2_epw/validation.py
@@ -1,0 +1,47 @@
+"""Pure, UI-free validation helpers for the NLR -> EPW app.
+
+These rules live in the library package (rather than in ``app/streamlit_app.py``)
+so they can be unit-tested directly. The Streamlit UI module is hard to exercise
+end-to-end and is excluded from coverage, so a length-check regression once
+shipped there unnoticed and disabled the request button. Keeping the logic here
+means the test suite actually covers it.
+"""
+
+import hashlib
+from typing import Optional
+
+# NLR / api.data.gov keys are exactly this many characters.
+API_KEY_LENGTH = 40
+
+
+def normalize_api_key(raw: Optional[str]) -> str:
+    """Trim surrounding whitespace, treating ``None`` as an empty key.
+
+    Keys read from ``st.secrets`` or environment variables frequently carry a
+    trailing newline; normalizing once keeps every downstream check honest.
+    """
+    return (raw or "").strip()
+
+
+def is_api_key_verified(api_key: Optional[str], valid_hash: str) -> bool:
+    """True if the whitespace-trimmed key hashes to ``valid_hash``."""
+    key = normalize_api_key(api_key)
+    if not key:
+        return False
+    return hashlib.sha256(key.encode()).hexdigest() == valid_hash
+
+
+def is_api_key_valid(api_key: Optional[str], *, is_verified: bool = False) -> bool:
+    """Whether a key is usable for an NLR request.
+
+    A key is valid if it is the verified default key, or if it is exactly
+    :data:`API_KEY_LENGTH` characters after trimming whitespace. The trim is the
+    point: a verified key with a stray trailing newline used to read as 41
+    characters and silently disable the request button.
+    """
+    key = normalize_api_key(api_key)
+    if not key:
+        return False
+    if is_verified:
+        return True
+    return len(key) == API_KEY_LENGTH

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,80 @@
+import hashlib
+
+from nlr_psm3_2_epw.validation import (
+    API_KEY_LENGTH,
+    is_api_key_valid,
+    is_api_key_verified,
+    normalize_api_key,
+)
+
+
+def _key(n: int) -> str:
+    return "a" * n
+
+
+# --- normalize_api_key -------------------------------------------------------
+
+
+def test_normalize_api_key_handles_none():
+    assert normalize_api_key(None) == ""
+
+
+def test_normalize_api_key_strips_surrounding_whitespace():
+    assert normalize_api_key("  abc\n") == "abc"
+
+
+# --- is_api_key_verified -----------------------------------------------------
+
+
+def test_is_api_key_verified_true_for_matching_hash():
+    key = _key(API_KEY_LENGTH)
+    digest = hashlib.sha256(key.encode()).hexdigest()
+    assert is_api_key_verified(key, digest) is True
+
+
+def test_is_api_key_verified_ignores_surrounding_whitespace():
+    key = _key(API_KEY_LENGTH)
+    digest = hashlib.sha256(key.encode()).hexdigest()
+    # a stray trailing newline must not change verification
+    assert is_api_key_verified(f"  {key}\n", digest) is True
+
+
+def test_is_api_key_verified_false_for_mismatch():
+    assert is_api_key_verified(_key(API_KEY_LENGTH), "deadbeef") is False
+
+
+def test_is_api_key_verified_false_for_empty():
+    assert is_api_key_verified("   ", "deadbeef") is False
+    assert is_api_key_verified(None, "deadbeef") is False
+
+
+# --- is_api_key_valid --------------------------------------------------------
+
+
+def test_is_api_key_valid_empty_is_false():
+    assert is_api_key_valid("") is False
+    assert is_api_key_valid(None) is False
+    assert is_api_key_valid("   ") is False
+
+
+def test_is_api_key_valid_exact_length():
+    assert is_api_key_valid(_key(API_KEY_LENGTH)) is True
+
+
+def test_is_api_key_valid_wrong_length():
+    assert is_api_key_valid(_key(API_KEY_LENGTH - 1)) is False
+    assert is_api_key_valid(_key(API_KEY_LENGTH + 1)) is False
+
+
+def test_is_api_key_valid_trims_before_length_check():
+    # Regression: a 40-char key with a trailing newline (as delivered by
+    # st.secrets / env vars) was read as 41 chars and disabled the button.
+    assert is_api_key_valid(f"{_key(API_KEY_LENGTH)}\n") is True
+
+
+def test_is_api_key_valid_verified_default_bypasses_length():
+    assert is_api_key_valid(_key(10), is_verified=True) is True
+
+
+def test_is_api_key_valid_verified_but_empty_is_false():
+    assert is_api_key_valid("", is_verified=True) is False


### PR DESCRIPTION
## What broke
The deployed app's **Request from NLR** button was permanently disabled even with a valid, *verified* API key.

[534827f](https://github.com/SustainableUrbanSystemsLab/NLR-PSM3-2-EPW/commit/534827f) gated the button on `len(api_key) == 40` and never trimmed the loaded key. A key from `st.secrets` / env var with a trailing newline reads as **41 chars** → passes hash verification ("Default API key loaded (Verified) ✅") yet stays disabled. Any user key not *exactly* 40 chars was likewise blocked. The app could no longer do its one job.

## Why tests didn't catch it
The validation logic lived entirely in `app/streamlit_app.py`, which has **zero tests** and is **excluded from coverage** (`source = ["nlr_psm3_2_epw"]`). The "100% coverage" gate only covers the library, not the UI. The one app-level integration test is skipped (no `APIKEY`).

## Fix
- Extract the rules into a pure, UI-free `nlr_psm3_2_epw/validation.py` (`normalize_api_key`, `is_api_key_verified`, `is_api_key_valid`) so the suite can actually cover them.
- Trim keys on **every** load path; treat a **verified default** key as valid regardless of length.
- Add `tests/test_validation.py` — 12 cases incl. the trailing-newline regression.

## Verification (via `uv`)
- `uv run ruff check` → clean
- `uv run pytest` → **35 passed, 1 skipped**, `validation.py` 100%, total **100%** retained
- Drove the patched app headless with a 40-char key + trailing newline → button **enabled** (was disabled pre-fix), no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)