### PR TITLE
fix: make semantic-release recognize gitmoji commits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,27 @@ version_toml = [
     "pyproject.toml:project.version",
 ]
 build_command = "pip install build && python -m build"
+# This project's commits use gitmoji (the Palette/Jules bot emits "🎨 …"),
+# not Conventional Commits, so the default "conventional" parser matched
+# nothing and no release was ever cut (frozen at 0.5.0). Use the emoji parser.
+commit_parser = "emoji"
+
+[tool.semantic_release.commit_parser_options]
+major_tags = ["💥"]
+minor_tags = ["✨", "🎉", "🚀", "💫", "🌟"]
+patch_tags = [
+    "🎨",  # :art: structure/format — Palette UI commits
+    "🐛",  # :bug:
+    "🚑",  # :ambulance: hotfix
+    "⚡️", "⚡",  # :zap: performance — Bolt commits
+    "🔒", "🔐",  # :lock: security
+    "♻️",  # :recycle: refactor
+    "🔧",  # :wrench: config
+    "📝",  # :memo: docs
+    "💄",  # :lipstick: UI/style
+    "🩹",  # :adhesive_bandage: minor fix
+    "⬆️", "⬇️", "📌",  # dependency bumps / pins
+]
 
 [tool.semantic_release.branches.main]
 match = "(main|master)"


### PR DESCRIPTION
## What's broken
Automatic versioning has been **frozen at v0.5.0 since January**. The `Release` workflow runs green on every push to `main`, but always concludes `no_release` — no tag, no version bump, no GitHub release.

Run log (latest):
```
Found 69 commits since the last release!
The type of the next release is: no_release
No release will be made, 0.5.0 has already been released!
```

## Cause
`python-semantic-release` defaults to the **Conventional Commits** parser, but this repo doesn't use conventional commits. Of the 69 commits since v0.5.0:
- 16× `🎨 Palette: …` (Palette/Jules UI bot)
- 12× dependabot `Bump …`
- perf `⚡️ Bolt …`, plus misc

None match `feat:`/`fix:`/etc., so the parser bumps nothing.

## Fix
Switch `commit_parser` to **`emoji`** and map the gitmoji this repo actually uses to bump levels — `🎨` (and other structure/format/fix/dep gitmoji) → **patch**, `✨` → minor, `💥` → major.

## Verification
`semantic-release version --print` over real history:
| parser | next release | version |
|---|---|---|
| conventional (before) | `no_release` | 0.5.0 |
| **emoji (after)** | **`patch`** | **0.5.1** |

Once merged, the next push to `main` cuts **v0.5.1** and sweeps up all 69 pending commits.

### Note on commit style going forward
The emoji parser keys off gitmoji, so human PRs should lead the subject with a gitmoji (`🐛` fix, `✨` feature, `💥` breaking) to trigger a release. The Palette bot already does this. (Alternative — adopt Conventional Commits everywhere and revert this — is a bigger process change; this matches the repo's existing convention.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)