### PR TITLE
🐛 fix: fall back to core attributes when NLR TMY rejects the full set

### DIFF
--- a/nlr_psm3_2_epw/assets.py
+++ b/nlr_psm3_2_epw/assets.py
@@ -12,6 +12,29 @@ from .constants import GOES_AGGREGATED_URL, GOES_TMY_URL, DEFAULT_HEADERS
 # Bolt Optimization: Maintain a global session to reuse TCP connections
 _session = requests.Session()
 
+# Attributes that are not available at every location for the NLR TMY product.
+# Requesting them at a point where they have no data makes the API return
+# 400 "Data processing failure" (the clearsky / QA fields are also unused by the
+# EPW writer). download_epw retries without these and fills the affected EPW
+# columns with the standard "missing" sentinels.
+BEST_EFFORT_ATTRIBUTES = frozenset(
+    {
+        "cloud_type",
+        "surface_albedo",
+        "total_precipitable_water",
+        "clearsky_dhi",
+        "clearsky_dni",
+        "clearsky_ghi",
+        "fill_flag",
+        "solar_zenith_angle",
+    }
+)
+
+
+def _column_or(df: pd.DataFrame, name: str, missing: Any):
+    """Return a DataFrame column's values if present, else an EPW missing sentinel."""
+    return df[name].values if name in df.columns else missing
+
 
 def _sanitize_url(raw_url: str) -> str:
     """Removes the api_key from a URL for safe logging."""
@@ -67,6 +90,16 @@ def download_epw(
 
     url = GOES_TMY_URL if is_tmy else GOES_AGGREGATED_URL
 
+    # Attribute fallback chain: request everything first, then retry with only the
+    # core solar+meteorological attributes that exist at every location. This
+    # avoids the API's 400 "Data processing failure" when a best-effort attribute
+    # (cloud_type / surface_albedo / ...) has no data at the requested point.
+    requested_attrs = [a.strip() for a in str(attributes).split(",") if a.strip()]
+    core_attrs = [a for a in requested_attrs if a not in BEST_EFFORT_ATTRIBUTES]
+    attribute_attempts = [",".join(requested_attrs)]
+    if core_attrs and core_attrs != requested_attrs:
+        attribute_attempts.append(",".join(core_attrs))
+
     payload = {
         "names": year,
         "leap_day": leap_year,
@@ -87,7 +120,12 @@ def download_epw(
     try:
         # Bolt Optimization: Use the session object to reuse the underlying TCP/TLS connection.
         # This speeds up repeated requests to the NLR API by avoiding repeated handshakes.
-        r = _session.request("GET", url, params=payload, headers=headers, timeout=20)
+        for attempt_attributes in attribute_attempts:
+            payload["attributes"] = attempt_attributes
+            r = _session.request("GET", url, params=payload, headers=headers, timeout=20)
+            if r.ok:
+                break
+
         # Redact API key for safety before potentially logging payload/url in an error
         payload["api_key"] = "REDACTED"
 
@@ -177,6 +215,13 @@ def download_epw(
         str(elevation),
     ]
 
+    # Best-effort columns: if the API dropped them (attribute unavailable at this
+    # location, so we fell back to the core set), fill with EPW "missing" sentinels
+    # rather than raising a KeyError.
+    cloud_cover = _column_or(df, "Cloud Type", 99)
+    precipitable_water = _column_or(df, "Precipitable Water", 999)
+    surface_albedo = _column_or(df, "Surface Albedo", 999)
+
     # Bolt Optimization:
     # Avoid pandas `.to_numpy()` and pandas `.multiply()` overhead during DataFrame construction.
     # Using underlying numpy `.values` directly, computing operations on the numpy arrays,
@@ -207,17 +252,17 @@ def download_epw(
             "Zenith Luminance": 9999,
             "Wind Direction": df["Wind Direction"].values,
             "Wind Speed": df["Wind Speed"].values,
-            "Total Sky Cover": df["Cloud Type"].values,
-            "Opaque Sky Cover": df["Cloud Type"].values,
+            "Total Sky Cover": cloud_cover,
+            "Opaque Sky Cover": cloud_cover,
             "Visibility": 9999,
             "Ceiling Height": 99999,
             "Present Weather Observation": "",
             "Present Weather Codes": "",
-            "Precipitable Water": df["Precipitable Water"].values,
+            "Precipitable Water": precipitable_water,
             "Aerosol Optical Depth": 0.999,
             "Snow Depth": 999,
             "Days Since Last Snowfall": 99,
-            "Albedo": df["Surface Albedo"].values,
+            "Albedo": surface_albedo,
             "Liquid Precipitation Depth": 999,
             "Liquid Precipitation Quantity": 99,
         },

--- a/tests/test_assets_unit.py
+++ b/tests/test_assets_unit.py
@@ -4,6 +4,7 @@ import requests
 
 from nlr_psm3_2_epw import assets
 from nlr_psm3_2_epw import constants
+from nlr_psm3_2_epw import epw
 
 
 class DummyResponse:
@@ -22,7 +23,7 @@ class DummyResponse:
         return self._json_data
 
 
-def _build_all_data(row_count, include_time_columns=True, bad_time=False):
+def _build_all_data(row_count, include_time_columns=True, bad_time=False, include_best_effort=True):
     columns = [
         "Local Time Zone",
         "Elevation",
@@ -47,6 +48,9 @@ def _build_all_data(row_count, include_time_columns=True, bad_time=False):
     ]
     if not include_time_columns:
         columns = [col for col in columns if col not in {"Year", "Month", "Day", "Hour", "Minute"}]
+    if not include_best_effort:
+        # Simulate the API dropping best-effort attributes on the core-only retry.
+        columns = [col for col in columns if col not in {"Cloud Type", "Precipitable Water", "Surface Albedo"}]
 
     metadata = {col: "" for col in columns}
     metadata["Local Time Zone"] = -5
@@ -58,22 +62,21 @@ def _build_all_data(row_count, include_time_columns=True, bad_time=False):
     data_rows = []
     for idx in range(row_count):
         row = {col: 0 for col in columns}
-        row.update(
-            {
-                "Temperature": 20 + idx,
-                "Dew Point": 10 + idx,
-                "Relative Humidity": 50,
-                "Pressure": 1013,
-                "GHI": 200,
-                "DNI": 500,
-                "DHI": 100,
-                "Wind Direction": 180,
-                "Wind Speed": 3,
-                "Cloud Type": 1,
-                "Precipitable Water": 1.5,
-                "Surface Albedo": 0.2,
-            }
-        )
+        values = {
+            "Temperature": 20 + idx,
+            "Dew Point": 10 + idx,
+            "Relative Humidity": 50,
+            "Pressure": 1013,
+            "GHI": 200,
+            "DNI": 500,
+            "DHI": 100,
+            "Wind Direction": 180,
+            "Wind Speed": 3,
+            "Cloud Type": 1,
+            "Precipitable Water": 1.5,
+            "Surface Albedo": 0.2,
+        }
+        row.update({k: v for k, v in values.items() if k in columns})
         if include_time_columns:
             if bad_time and idx == 0:
                 row.update({"Year": "bad", "Month": "bad", "Day": "bad", "Hour": "bad", "Minute": "bad"})
@@ -346,3 +349,55 @@ def test_download_epw_sanitizes_bad_lat_lon(monkeypatch, tmp_path):
     # Filename should use "bad-lat" and "bad-lon" strings directly, and sanitize location
     current_year = assets.datetime.now().year
     assert (tmp_path / f"Loc_w__Spaces_bad-lat_bad-lon_2012_{current_year}.epw").exists()
+
+
+def test_download_epw_retries_without_best_effort_attributes(monkeypatch, tmp_path):
+    # First request (full attribute set) fails like a location where a best-effort
+    # attribute is unavailable (400 "Data processing failure"); the retry with the
+    # core-only set succeeds, and the dropped columns are filled with EPW sentinels.
+    core_only_data = _build_all_data(3, include_time_columns=True, include_best_effort=False)
+
+    attempts = []
+
+    def _fake_request(_method, _url, params=None, **_kwargs):
+        attempts.append(params["attributes"])
+        if len(attempts) == 1:
+            return DummyResponse(
+                ok=False,
+                url="https://example.com/data?api_key=secret",
+                status_code=400,
+                json_data={"errors": ["Data processing failure."]},
+            )
+        return DummyResponse(ok=True, url="https://example.com/data")
+
+    monkeypatch.setattr(assets._session, "request", _fake_request)
+    monkeypatch.setattr(assets.pd, "read_csv", _mock_read_csv(core_only_data))
+    monkeypatch.chdir(tmp_path)
+
+    attributes = (
+        "air_temperature,cloud_type,surface_albedo,total_precipitable_water,ghi,dni,dhi,"
+        "dew_point,relative_humidity,surface_pressure,wind_direction,wind_speed"
+    )
+    assets.download_epw(
+        0, 0, "tmy", "Loc", attributes, "60", "false", "Name", "key", "reason", "aff", "email", "false", "false"
+    )
+
+    # Two attempts: full set, then core-only (best-effort attributes dropped).
+    assert len(attempts) == 2
+    assert "cloud_type" in attempts[0]
+    assert "cloud_type" not in attempts[1]
+    assert "surface_albedo" not in attempts[1]
+
+    epw_files = list(tmp_path.glob("*.epw"))
+    assert len(epw_files) == 1
+
+    # Restore the real pd.read_csv (patched above at module level) so the EPW
+    # read-back parses the written file instead of the mocked reader.
+    monkeypatch.undo()
+    data = epw.EPW()
+    data.read(epw_files[0])
+    # Dropped best-effort columns are filled with EPW "missing" sentinels.
+    assert (data.dataframe["Total Sky Cover"] == 99).all()
+    assert (data.dataframe["Opaque Sky Cover"] == 99).all()
+    assert (data.dataframe["Precipitable Water"] == 999).all()
+    assert (data.dataframe["Albedo"] == 999).all()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -7,13 +7,20 @@ from nlr_psm3_2_epw import epw
 from nlr_psm3_2_epw.assets import download_epw
 
 
-def test_download_epw(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "lat,lon,location",
+    [
+        (40.755840, -73.982684, "NYC"),
+        # Sparse-attribute land point that used to return 400 "Data processing
+        # failure" for the full attribute set — exercises the core-only fallback.
+        (45.935870621190546, -112.994384765625, "Montana"),
+    ],
+)
+def test_download_epw(tmp_path, monkeypatch, lat, lon, location):
     api_key = os.environ.get("APIKEY")
     if not api_key:
         pytest.skip("APIKEY not set")
 
-    lat, lon = 40.755840, -73.982684
-    location = "NYC"
     year = "tmy"
     attributes = (
         "air_temperature,clearsky_dhi,clearsky_dni,clearsky_ghi,cloud_type,dew_point,dhi,dni,fill_flag,ghi,"
@@ -69,7 +76,13 @@ def test_download_epw(tmp_path, monkeypatch):
     assert (data.dataframe["Global Horizontal Radiation"] >= 0).all()
     assert (data.dataframe["Direct Normal Radiation"] >= 0).all()
     assert (data.dataframe["Diffuse Horizontal Radiation"] >= 0).all()
-    assert ((data.dataframe["Wind Direction"] >= 0) & (data.dataframe["Relative Humidity"] <= 360)).all()
+    assert ((data.dataframe["Wind Direction"] >= 0) & (data.dataframe["Wind Direction"] <= 360)).all()
     assert ((data.dataframe["Wind Speed"] >= 0) & (data.dataframe["Wind Speed"] <= 40)).all()
-    assert ((data.dataframe["Opaque Sky Cover"] >= 0) & (data.dataframe["Opaque Sky Cover"] <= 10)).all()
-    assert ((data.dataframe["Total Sky Cover"] >= 0) & (data.dataframe["Total Sky Cover"] <= 10)).all()
+
+    # Sky cover is 0-10 where available, or the EPW "missing" sentinel (99) at
+    # locations where cloud_type was dropped by the core-only fallback.
+    def _sky_ok(series):
+        return (((series >= 0) & (series <= 10)) | (series == 99)).all()
+
+    assert _sky_ok(data.dataframe["Opaque Sky Cover"])
+    assert _sky_ok(data.dataframe["Total Sky Cover"])


### PR DESCRIPTION
## Symptom
Deployed app (https://nrel-psm3-2-epw.streamlit.app/) fails for some locations:
```
NLR request failed (400) ... {'status': 400, 'errors': ['Data processing failure.']}
```

## Root cause
The app requests **17 attributes** for a TMY download. NLR returns `400 "Data processing failure"` when a requested attribute has **no data at the chosen point**. Reproduced with `DEMO_KEY`:
- `names=tmy` and small attribute sets → **302 (data exists)** at the failing Montana point (45.94, −112.99)
- the full attribute set → **400** there
- the same full set at **NYC** (40.76, −73.98) → **succeeds**

So it's a **location-dependent attribute gap** (cloud_type / surface_albedo / total_precipitable_water are sparse at some land points). Not caused by the recent PRs — `download_epw` was never touched.

## Why CI didn't catch it
`test_download.py` *does* exercise the real API with `year="tmy"` and the full attribute set, and **runs green in CI** (APIKEY secret is set). But it only tested **one location (NYC)**, which has complete data. Single-location integration coverage → location-dependent gaps slip through.

## Fix
`download_epw` now:
1. Requests the full attribute set, then **retries with only the core solar+meteorological attributes** that exist everywhere.
2. Fills the dropped EPW columns (Total/Opaque Sky Cover, Precipitable Water, Albedo) with the standard EPW **missing sentinels** (99 / 999).

Any land location with core solar data now produces a file.

## Tests
- **Unit** (`test_assets_unit.py`): mocked retry — first request 400, core-only retry succeeds, dropped columns written as sentinels. **100% coverage kept.**
- **Integration** (`test_download.py`): now **parametrized over NYC + the Montana point** that used to 400. Runs in CI with the real `APIKEY` secret, so this class of failure is caught going forward. Also fixed a copy-paste bug (wind-direction bound checked Relative Humidity) and relaxed the sky-cover assertion to accept the sentinel.

**The CI run on this PR is the live validation** — it exercises the Montana fallback against the real API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)