### PR TITLE
📝 docs: SEO for README + app meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,91 @@
-# NLR-PSM3-2-EPW
+# NLR-PSM3-2-EPW — Convert NREL PSM3 / NSRDB Solar Data to EnergyPlus EPW Weather Files
+
 [![Build-Test](https://github.com/SustainableUrbanSystemsLab/NLR-PSM3-2-EPW/actions/workflows/build-test.yml/badge.svg?branch=main)](https://github.com/SustainableUrbanSystemsLab/NLR-PSM3-2-EPW/actions/workflows/build-test.yml)
 [![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://nrel-psm3-2-epw.streamlit.app/)
-[![Version](https://img.shields.io/badge/version-v4.0.0-blue)](https://github.com/SustainableUrbanSystemsLab/NLR-PSM3-2-EPW/releases)
+[![Latest Release](https://img.shields.io/github/v/release/SustainableUrbanSystemsLab/NLR-PSM3-2-EPW?label=release)](https://github.com/SustainableUrbanSystemsLab/NLR-PSM3-2-EPW/releases)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
+**NLR-PSM3-2-EPW** is a free, open-source Python tool and Streamlit web app that converts
+**NREL Physical Solar Model (PSM v3.2.2 / v4.0.0, NSRDB)** solar and meteorological data into
+**EnergyPlus Weather (EPW)** files for building energy simulation. Pick any location by
+latitude / longitude and download a ready-to-use `.epw` for a specific year or a
+**Typical Meteorological Year (TMY)**.
 
+👉 **Try the live app:** <https://nrel-psm3-2-epw.streamlit.app/>
 
-A script and Streamlit app that writes out EPW files from NLR Physical Solar Model (PSM) v3.2.2 (and v4.0.0 API).
+## What it does
+
+Downloads solar irradiance (**GHI, DNI, DHI**), dry-bulb temperature, dew point, relative
+humidity, atmospheric pressure, wind speed/direction, cloud cover, surface albedo and
+precipitable water from the **NSRDB** API, then writes a standards-compliant **EPW** weather
+file compatible with **EnergyPlus, OpenStudio, Ladybug / Honeybee, DesignBuilder, IES-VE**
+and other building-performance simulation tools.
+
+## Why
+
+Getting hourly weather data into an EnergyPlus-ready EPW file usually means manual API calls
+and column wrangling. This tool automates the full **NSRDB → EPW** pipeline — click a point
+on a map, choose a year or TMY, and download the weather file.
 
 ## Features
 
--   **EPW Conversion**: Converts NLR solar data to EnergyPlus Weather format.
--   **Streamlit App**: User-friendly interface for downloading data.
--   **Secure**: API keys are managed via Streamlit secrets and verified with hash checks.
--   **Modern Stack**: Built with `uv` for dependency management and `ruff` for code quality.
+- **PSM3 / NSRDB → EPW conversion** — turns NREL solar climate data into EnergyPlus Weather format.
+- **Interactive map** — pick a location by clicking, or enter latitude / longitude manually.
+- **TMY and single-year datasets** — download `tmy`, `tgy`, `tdy`, or a specific historical year (≥ 1998).
+- **Resilient downloads** — automatically falls back to core attributes when a dataset is
+  sparse at a location, so remote points still produce a valid EPW.
+- **Secure** — API keys are managed via Streamlit secrets and verified with a hash check.
+- **Modern stack** — `uv` for dependency management, `ruff` for linting, 100% unit-test coverage.
+
+## What is an EPW file?
+
+An **EnergyPlus Weather (EPW)** file is the standard hourly weather format consumed by
+EnergyPlus and most building energy simulation engines. It contains a full year (8760 hours)
+of solar, temperature, humidity, wind and sky-cover data for a single location, and is the
+starting point for energy modeling, daylighting and thermal-comfort analysis.
+
+## Keywords
+
+`EPW` · `EnergyPlus Weather file` · `PSM3` · `PSM v4` · `NSRDB` · `NREL` · `TMY` ·
+`typical meteorological year` · `solar radiation data` · `GHI / DNI / DHI` ·
+`building energy simulation` · `weather data converter` · `climate data`
 
 ## Project Structure
 
--   `app/`: Contains the Streamlit application code.
-    -   `streamlit_app.py`: Main entry point.
-    -   `.streamlit/secrets.toml`: (Not committed) Stores your API key.
--   `nlr_psm3_2_epw/`: Core transformation logic.
--   `tests/`: Unit tests (100% coverage).
+- `app/`: Streamlit application.
+    - `streamlit_app.py`: Main entry point.
+    - `.streamlit/secrets.toml`: (Not committed) Stores your API key.
+- `nlr_psm3_2_epw/`: Core transformation logic (NSRDB download + EPW writer).
+- `tests/`: Unit and integration tests (100% coverage).
 
 ## How to Run Locally
 
-1.  **Install dependencies with uv**:
+1. **Install dependencies with uv**:
     ```bash
     uv sync --extra dev
     ```
 
-2.  **Configure API Key**:
-    -   Create `app/.streamlit/secrets.toml`:
+2. **Configure your API key**:
+    - Create `app/.streamlit/secrets.toml`:
         ```toml
         APIKEY = "YOUR_NLR_API_KEY"
         ```
-    -   Request or manage your API key at `https://developer.nlr.gov/signup`
-    -   API documentation is available at `https://developer.nlr.gov`
-    -   *Note: The app verifies the default API key integrity.*
+    - Request or manage your API key at <https://developer.nlr.gov/signup>
+    - API documentation is available at <https://developer.nlr.gov>
+    - *Note: the app verifies the default API key integrity.*
 
-3.  **Run the App**:
+3. **Run the app**:
     ```bash
     uv run streamlit run app/streamlit_app.py
     ```
-    *(Windows users can use `run_streamlit.bat`)*
+    *(Windows users can use `run_streamlit.bat`.)*
 
-4.  **Run Tests**:
+4. **Run tests**:
     ```bash
     uv run pytest
     ```
 
-5.  **Lint & Format**:
+5. **Lint & format**:
     ```bash
     uv run ruff check --fix .
     uv run ruff format .
@@ -57,4 +93,8 @@ A script and Streamlit app that writes out EPW files from NLR Physical Solar Mod
 
 ## Demo
 
--   [Link to demo](https://nrel-psm3-2-epw.streamlit.app/)
+Live Streamlit app: <https://nrel-psm3-2-epw.streamlit.app/>
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from datetime import datetime
@@ -6,6 +7,7 @@ from typing import Optional
 
 import requests
 import streamlit as st
+import streamlit.components.v1 as components
 import folium
 from streamlit_folium import st_folium
 
@@ -19,6 +21,19 @@ from nlr_psm3_2_epw.validation import (
     is_api_key_verified,
     normalize_api_key,
 )
+
+# --- SEO METADATA ---
+SEO_TITLE = "PSM3 to EPW Converter — NREL / NSRDB EnergyPlus Weather Files"
+SEO_DESCRIPTION = (
+    "Free web app to convert NREL PSM v3/v4 (NSRDB) solar climate data into EnergyPlus "
+    "Weather (EPW) files for building energy simulation. Pick a location by latitude/"
+    "longitude and download a TMY or single-year EPW file."
+)
+SEO_KEYWORDS = (
+    "EPW, EnergyPlus Weather, PSM3, PSM v4, NSRDB, NREL, TMY, typical meteorological year, "
+    "solar radiation, GHI, DNI, DHI, building energy simulation, weather file converter, climate data"
+)
+SEO_URL = "https://nrel-psm3-2-epw.streamlit.app/"
 
 # --- CONSTANTS ---
 ATTRIBUTES = (
@@ -137,8 +152,77 @@ def get_map():
     return m
 
 
+def _inject_seo_meta() -> None:
+    """Inject SEO meta tags (description, keywords, Open Graph, Twitter, canonical)
+    into the host page's <head>.
+
+    Streamlit renders the app inside a host page whose <head> is otherwise generic.
+    This runs a tiny hidden component whose script writes the tags into the parent
+    document so JavaScript-capable crawlers (e.g. Googlebot) can index them.
+    """
+    meta = {
+        "title": SEO_TITLE,
+        "url": SEO_URL,
+        "named": {
+            "description": SEO_DESCRIPTION,
+            "keywords": SEO_KEYWORDS,
+            "robots": "index, follow",
+            "twitter:card": "summary",
+            "twitter:title": SEO_TITLE,
+            "twitter:description": SEO_DESCRIPTION,
+        },
+        "property": {
+            "og:type": "website",
+            "og:title": SEO_TITLE,
+            "og:description": SEO_DESCRIPTION,
+            "og:url": SEO_URL,
+        },
+    }
+    components.html(
+        """
+        <script>
+        (function () {
+            try {
+                var data = %s;
+                var doc = window.parent.document;
+                if (!doc || !doc.head) return;
+                doc.title = data.title;
+                function upsert(selector, attr, key, content) {
+                    var el = doc.head.querySelector(selector);
+                    if (!el) {
+                        el = doc.createElement("meta");
+                        el.setAttribute(attr, key);
+                        doc.head.appendChild(el);
+                    }
+                    el.setAttribute("content", content);
+                }
+                Object.keys(data.named).forEach(function (k) {
+                    upsert('meta[name="' + k + '"]', "name", k, data.named[k]);
+                });
+                Object.keys(data.property).forEach(function (k) {
+                    upsert('meta[property="' + k + '"]', "property", k, data.property[k]);
+                });
+                var canon = doc.head.querySelector('link[rel="canonical"]');
+                if (!canon) {
+                    canon = doc.createElement("link");
+                    canon.setAttribute("rel", "canonical");
+                    doc.head.appendChild(canon);
+                }
+                canon.setAttribute("href", data.url);
+            } catch (e) {
+                /* cross-origin or unavailable head: ignore */
+            }
+        })();
+        </script>
+        """
+        % json.dumps(meta),
+        height=0,
+    )
+
+
 def main():
-    st.set_page_config(page_title="NLR to EPW", page_icon="☀️")
+    st.set_page_config(page_title=SEO_TITLE, page_icon="☀️")
+    _inject_seo_meta()
     st.title("NLR-PSM3-2-EPW")
     st.caption(f"**Version {__version__}**")
     st.markdown("This script converts climate data from NLR to the EnergyPlus Weather (EPW) format.")


### PR DESCRIPTION
## SEO coverage — README + app

### README
- Keyword-rich H1 + intro: EPW, EnergyPlus Weather, PSM3 / PSM v4, NSRDB, NREL, TMY, GHI/DNI/DHI, building energy simulation.
- Added "What it does", "What is an EPW file?", and a **Keywords** block for search intent.
- Replaced the stale hard-coded `v4.0.0` version badge with a **dynamic release badge** (auto-tracks releases), plus a license badge.

### App
- Keyword-rich `page_title` (sets `<title>`).
- Injects `<meta>` **description / keywords / robots**, **Open Graph**, **Twitter card**, and a **canonical** link into the host page `<head>` via a hidden component, so JS-capable crawlers (Googlebot) can index them.

### Verified at runtime (headless + Playwright)
```
title:       PSM3 to EPW Converter — NREL / NSRDB EnergyPlus Weather Files
description: Free web app to convert NREL PSM v3/v4 (NSRDB) solar climate data ...
keywords:    EPW, EnergyPlus Weather, PSM3, PSM v4, NSRDB, NREL, TMY, ...
og:title / og:url / twitter:card / canonical  → all present
```

ruff clean, `uv run pytest` → 36 passed / 2 skipped, 100% coverage (app is not in coverage source; core unchanged).

Repo topics + description updated separately (fixed `psb3` typos, added `nsrdb`, `tmy`, `streamlit`, `solar-radiation`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)