### PR TITLE
🎨 Palette: [validation] distinguish empty state from active invalid input errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -118,3 +118,7 @@
 ## 2024-05-24 - Symmetrical Inline Guidance for Multi-Column Layouts
 **Learning:** When arranging form inputs in multi-column layouts (like `st.columns`), providing inline instructions (`st.caption`) for one field but not the adjacent field not only deprives the user of context but creates an unbalanced visual hierarchy.
 **Action:** Ensure symmetrical levels of inline guidance in multi-column layouts. If one column requires extensive explanation, provide at least a brief, helpful instruction for the adjacent column to maintain layout balance and improve overall form accessibility.
+
+## 2024-07-01 - Distinguish Empty States from Invalid Inputs
+**Learning:** In Streamlit applications, visually distinguish between preliminary empty states and actively invalid user input to improve form accessibility. Using a generic `st.warning` for both missing inputs and explicitly incorrect inputs (e.g., malformed API keys) can confuse users about the severity of their error.
+**Action:** Use a softer `st.warning` with helpful icons (e.g., '⚠️') for missing preliminary inputs, but upgrade to `st.error` with appropriate icons (e.g., '🛑') when inputs are explicitly provided but actively invalid (e.g., malformed API keys or out-of-bounds years).

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -413,21 +413,22 @@ def main():
 
     # A verified default key is usable regardless of length; any other key must
     # be exactly API_KEY_LENGTH characters (whitespace already trimmed on load).
-    api_key_is_valid = is_api_key_valid(
-        api_key, is_verified=(api_key_source == "default" and default_key_verified)
-    )
+    api_key_is_valid = is_api_key_valid(api_key, is_verified=(api_key_source == "default" and default_key_verified))
 
     # Full-width validation warnings below inputs
     if not location_is_valid:
         st.warning("A location name is required to generate the file.", icon="⚠️")
 
     if not year_is_valid:
-        st.warning(year_warning, icon="⚠️")
+        if year_str:
+            st.error(year_warning, icon="🛑")
+        else:
+            st.warning(year_warning, icon="⚠️")
 
     if not api_key:
         st.warning("Please provide an API key in the 'API Key Configuration' section to request data.", icon="🔑")
     elif not api_key_is_valid:
-        st.warning("The provided API key must be exactly 40 characters long to request data.", icon="⚠️")
+        st.error("The provided API key must be exactly 40 characters long to request data.", icon="🛑")
 
     if st.button(
         "Request from NLR",

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ wheels = [
 
 [[package]]
 name = "nlr-psm3-2-epw"
-version = "0.5.0"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
**What:** Upgraded actively invalid input validation messages from `st.warning` to `st.error`.

**Why:** To clearly distinguish between preliminary empty states (which warrant a soft warning) and actual user mistakes (which warrant a clear error), reducing cognitive load and improving form accessibility.

**Impact:** Users now receive appropriate visual severity for their validation feedback.

**Measurement:** Verified code changes via `git diff` and ensured they logically match the standard UI validation flow. Tests pass successfully.

---
*PR created automatically by Jules for task [9508518222143056358](https://jules.google.com/task/9508518222143056358) started by @kastnerp*